### PR TITLE
Fix escaped `\=` parsing in InsertTranslationLines

### DIFF
--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -319,13 +319,13 @@ namespace MWC_Localization_Core
                     if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith("#"))
                         continue;
 
-                    int separatorIndex = line.IndexOf('=');
+                    int separatorIndex = FindKeyValueSeparatorIndex(line);
                     if (separatorIndex > 0)
                     {
-                        string key = line.Substring(0, separatorIndex).Trim();
+                        string key = line.Substring(0, separatorIndex).Trim().Replace("\\=", "=");
                         // Preserve intentional leading spaces in translation values.
                         // We only trim the end to avoid accidental trailing whitespace.
-                        string value = line.Substring(separatorIndex + 1).TrimEnd();
+                        string value = line.Substring(separatorIndex + 1).TrimEnd().Replace("\\=", "=");
 
                         // Common authoring style is: "key = value".
                         // In that specific case, drop only the single separator space.
@@ -353,6 +353,27 @@ namespace MWC_Localization_Core
             {
                 CoreConsole.Error($"[{Name}] Failed to load translations: {ex.Message}");
             }
+        }
+
+        private static int FindKeyValueSeparatorIndex(string line)
+        {
+            for (int i = 0; i < line.Length; i++)
+            {
+                if (line[i] != '=')
+                    continue;
+
+                int backslashCount = 0;
+                for (int j = i - 1; j >= 0 && line[j] == '\\'; j--)
+                {
+                    backslashCount++;
+                }
+
+                bool isEscaped = (backslashCount % 2) == 1;
+                if (!isEscaped)
+                    return i;
+            }
+
+            return -1;
         }
 
         void LoadTranslations()


### PR DESCRIPTION
### Motivation

- Translation lines containing an escaped equals (`\=`) were being split at the escaped `=` and treated as the key/value separator, causing incorrect key or value extraction for lines that include literal `=` characters.

### Description

- Replaced the simple `IndexOf('=')` split with a new helper `FindKeyValueSeparatorIndex` that returns the index of the first unescaped `=` in a line.
- After splitting, unescape `\=` back to `=` in both the parsed key and value to preserve literal equals in runtime strings while keeping existing spacing and `\n` handling behavior.
- Kept existing logic that trims trailing whitespace and handles the common authoring style `"key = value"` unchanged.

### Testing

- Attempted to run `dotnet build MWC_Localization_Core.sln` but the environment does not have `dotnet` installed, so no build/test could be completed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b90e81fd08327a138a310bc070217)