### PR TITLE
refactor: optimize localization runtime and clean legacy code

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -36,7 +36,6 @@ namespace MWC_Localization_Core
         // Cache for array proxies to avoid repeated lookups
         private Dictionary<string, PlayMakerArrayListProxy> arrayProxyCache 
             = new Dictionary<string, PlayMakerArrayListProxy>();
-        private Dictionary<string, bool> arrayRetryStateCache = new Dictionary<string, bool>();
 
         public ArrayListProxyHandler(
             Dictionary<string, string> translations, 
@@ -74,8 +73,8 @@ namespace MWC_Localization_Core
 
         private void InitializeTextMeshMappings()
         {
-            // Parent paths to search under - apply fonts to ALL TextMeshes under these paths
-            // Paths are specific enough that all children should get Korean fonts
+            // Parent paths to search under - apply fonts to all TextMeshes under these paths
+            // Paths are specific enough that all children should get the localized font mapping
             parentSearchPaths = new List<string>
             {
                 "GUI/HUD/Day",                            // HUD Day Display
@@ -93,7 +92,6 @@ namespace MWC_Localization_Core
             arrayProxyCache.Clear();
             fontAppliedInstances.Clear();
             completedParentPaths.Clear();
-            arrayRetryStateCache.Clear();
         }
 
         public void Reset()
@@ -102,7 +100,6 @@ namespace MWC_Localization_Core
             arrayProxyCache.Clear();
             fontAppliedInstances.Clear();
             completedParentPaths.Clear();
-            arrayRetryStateCache.Clear();
         }
 
         // Translate all configured arrays (call once per scene)
@@ -231,13 +228,6 @@ namespace MWC_Localization_Core
                         if (translated > 0) totalTranslated += translated;
                         translatedArrays.Add(arrayKey);
                     }
-                    
-                    bool currentState = isPopulated;
-                    bool cachedState;
-                    if (!arrayRetryStateCache.TryGetValue(arrayKey, out cachedState) || cachedState != currentState)
-                    {
-                        arrayRetryStateCache[arrayKey] = currentState;
-                    }
                 }
             }
 
@@ -264,7 +254,7 @@ namespace MWC_Localization_Core
             return null;
         }
 
-        // Apply Korean fonts to TextMesh components displaying array data
+        // Apply localized fonts to TextMesh components displaying array data
         // Call this once during scene initialization, then periodically until all paths are complete
         public int ApplyFontsToArrayElements()
         {

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -15,11 +15,16 @@ namespace MWC_Localization_Core
         private Dictionary<string, string> translations;
         private GameObject hostObject;
         private PatternMatcher patternMatcher;
-        private bool isApplied;
         private string appliedTarget;
         private HashSet<string> loggedReadyTargets = new HashSet<string>();
+        private HashSet<string> completedStrategyTargets = new HashSet<string>();
+        private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
         private float lastEnnusteDataFsmScanTime = -10f;
+
+        private static readonly WaitForSeconds BootstrapPollDelay = new WaitForSeconds(0.5f);
+        private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(3.0f);
+        private const float EnnusteDataRescanInterval = 10f;
 
         // Reflection cache: (Type, fieldName) -> FieldInfo to avoid repeated GetField calls
         private static readonly Dictionary<System.Type, Dictionary<string, FieldInfo>> reflectionCache
@@ -220,45 +225,52 @@ namespace MWC_Localization_Core
 
         private IEnumerator ApplyWhenReady()
         {
-            while (!isApplied)
+            while (hostObject != null)
             {
                 string currentScene = Application.loadedLevelName;
 
-                if (TryApplyTranslations(currentScene))
+                if (currentScene == "MainMenu")
                 {
-                    isApplied = true;
-                    string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
-                    CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
-                    Cleanup();
-                    yield break;
+                    if (TryApplyMainMenuTranslations())
+                    {
+                        appliedTarget = "MainMenu";
+                        string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
+                        CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
+                        Cleanup();
+                        yield break;
+                    }
+
+                    yield return BootstrapPollDelay;
+                    continue;
                 }
 
-                // Poll at a small interval so delayed/hidden FSMs can be picked up after user interaction.
-                yield return new WaitForSeconds(0.25f);
+                if (currentScene == "GAME")
+                {
+                    TryApplyGameTranslations();
+                    yield return MaintenancePollDelay;
+                    continue;
+                }
+
+                yield return BootstrapPollDelay;
             }
         }
 
-        private bool TryApplyTranslations(string currentScene)
+        private void TryApplyGameTranslations()
         {
             if (translations == null)
-                return false;
+                return;
 
-            if (currentScene == "MainMenu" && TryApplyMainMenuTranslations())
+            bool anyChanged = false;
+            anyChanged |= TryApplyGamePosFsmTranslations();
+            anyChanged |= TryApplyGameTeletextBottomlineFsmTranslations();
+            anyChanged |= TryApplyGameTeletextWeatherUpdaterFsmTranslations();
+            anyChanged |= TryApplyGameUnemployPaperFsmTranslations();
+
+            if (anyChanged)
             {
-                appliedTarget = "MainMenu";
-                return true;
+                string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "GAME" : appliedTarget;
+                CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
             }
-
-            if (currentScene == "GAME")
-            {
-                // Keep this hook alive in GAME to refresh dynamic POS FSM string buffers.
-                TryApplyGamePosFsmTranslations();
-                TryApplyGameTeletextBottomlineFsmTranslations();
-                TryApplyGameTeletextWeatherUpdaterFsmTranslations();
-                TryApplyGameUnemployPaperFsmTranslations();
-            }
-
-            return false;
         }
 
         private bool TryApplyMainMenuTranslations()
@@ -336,8 +348,13 @@ namespace MWC_Localization_Core
                 if (!IsFsmReady(fsm))
                     continue;
 
+                int instanceID = fsm.GetInstanceID();
+                if (completedEnnusteFsmInstances.Contains(instanceID))
+                    continue;
+
                 LogReadyOnce("TTX_WX_READY", "[FsmTextHook] Teletext weather updater FSM targets are ready.");
                 ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
+                completedEnnusteFsmInstances.Add(instanceID);
             }
 
             if (anyChanged)
@@ -374,13 +391,23 @@ namespace MWC_Localization_Core
                 if (target == null)
                     continue;
 
+                string targetKey = BuildTargetKey(target);
+                if (completedStrategyTargets.Contains(targetKey))
+                    continue;
+
                 PlayMakerFSM fsm = MLCUtils.FindFsmIncludingInactiveByPathAndName(target.ObjectPath, target.FsmName);
                 if (!IsFsmReady(fsm))
                     continue;
 
                 LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
                 ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
+                completedStrategyTargets.Add(targetKey);
             }
+        }
+
+        private static string BuildTargetKey(FsmStrategyTarget target)
+        {
+            return target.ObjectPath + "|" + target.FsmName + "|" + target.Strategy.ToString() + "|" + target.StateName + "|" + target.ActionIndex.ToString();
         }
 
         private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
@@ -499,7 +526,7 @@ namespace MWC_Localization_Core
 
         private List<PlayMakerFSM> GetEnnusteDataFsms()
         {
-            bool shouldRescan = cachedEnnusteDataFsms.Count == 0 || (Time.realtimeSinceStartup - lastEnnusteDataFsmScanTime) >= 2f;
+            bool shouldRescan = cachedEnnusteDataFsms.Count == 0 || (Time.realtimeSinceStartup - lastEnnusteDataFsmScanTime) >= EnnusteDataRescanInterval;
             if (!shouldRescan)
                 return cachedEnnusteDataFsms;
 

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -34,7 +34,6 @@ namespace MWC_Localization_Core
         private float lastArrayCheckTime = 0f;
 
         public void Initialize(
-            TextMeshTranslator translatorInstance,
             UnifiedTextMeshMonitor textMeshMonitorInstance,
             TeletextHandler teletextHandlerInstance,
             ArrayListProxyHandler arrayListHandlerInstance,

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -7,13 +7,11 @@ namespace MWC_Localization_Core
     /// <summary>
     /// MonoBehaviour component for ALL continuous translation monitoring
     /// Must run in LateUpdate() to translate AFTER game's Update() regenerates text
-    /// DIRECT COPY from Plugin.cs LateUpdate - all monitoring logic moved here
-    /// Same pattern as legacy LanguageFramework's MainObject for My Summer Car
+    /// Centralizes continuous translation work outside the main mod entry point
     /// </summary>
     public class LateUpdateHandler : MonoBehaviour
     {
         // Dependencies
-        private TextMeshTranslator translator;
         private UnifiedTextMeshMonitor textMeshMonitor;
         private TeletextHandler teletextHandler;
         private ArrayListProxyHandler arrayListHandler;
@@ -32,7 +30,7 @@ namespace MWC_Localization_Core
 
         private bool isInitialized = false;
         
-        // Throttling timers (MOVED from MWC_Localization_Core.cs)
+        // Throttling timer for array and proxy monitoring
         private float lastArrayCheckTime = 0f;
 
         public void Initialize(
@@ -43,7 +41,6 @@ namespace MWC_Localization_Core
             HashTableProxyHandler hashTableHandlerInstance,
             SceneTranslationManager sceneManagerInstance)
         {
-            translator = translatorInstance;
             textMeshMonitor = textMeshMonitorInstance;
             teletextHandler = teletextHandlerInstance;
             arrayListHandler = arrayListHandlerInstance;
@@ -63,7 +60,7 @@ namespace MWC_Localization_Core
 
             string currentScene = Application.loadedLevelName;
 
-            // GAME scene monitoring - EXACT COPY from Mod_Update
+            // GAME scene monitoring
             if (currentScene == "GAME" && sceneManager.HasSceneBeenTranslated("GAME"))
             {
                 // Throttled monitoring for regular TextMesh elements
@@ -99,7 +96,7 @@ namespace MWC_Localization_Core
                 }
             }
 
-            // Main menu monitoring - EXACT COPY from Mod_Update
+            // Main menu monitoring
             else if (currentScene == "MainMenu" && sceneManager.HasSceneBeenTranslated("MainMenu"))
             {
                 // Monitor for dynamic changes in main menu

--- a/LocalizationConstants.cs
+++ b/LocalizationConstants.cs
@@ -7,9 +7,9 @@ namespace MWC_Localization_Core
     public static class LocalizationConstants
     {
         // Monitoring strategies timing
-        public const float FAST_POLLING_INTERVAL = 0.1f;            // 10 times per second
+        public const float FAST_POLLING_INTERVAL = 0.15f;           // ~6.6 times per second
         public const float SLOW_POLLING_INTERVAL = 1.0f;            // Once per second
-        public const float VISIBILITY_POLLING_INTERVAL = 0.2f;      // 5 times per second
-        public const float ARRAY_MONITOR_INTERVAL = 1.0f;           // Check arrays every 1 second (was every frame)
+        public const float VISIBILITY_POLLING_INTERVAL = 0.35f;     // ~3 times per second
+        public const float ARRAY_MONITOR_INTERVAL = 2.0f;           // Check arrays every 2 seconds
     }
 }

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -38,7 +38,6 @@ namespace MWC_Localization_Core
         // Cache for expensive GameObject.Find(path) lookups
         private static Dictionary<string, GameObject> gameObjectFindCache = new Dictionary<string, GameObject>();
         // Cache for inactive lookup helpers (resolved via Resources.FindObjectsOfTypeAll)
-        private static Dictionary<string, TextMesh> inactiveTextMeshPathCache = new Dictionary<string, TextMesh>();
         private static Dictionary<string, PlayMakerFSM> inactiveFsmPathNameCache = new Dictionary<string, PlayMakerFSM>();
 
         public static string GetGameObjectPath(GameObject obj)
@@ -100,44 +99,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Find TextMesh by full object path, including inactive objects.
-        /// Uses a cache and falls back to Resources.FindObjectsOfTypeAll when needed.
-        /// </summary>
-        public static TextMesh FindTextMeshIncludingInactiveByPath(string fullPath)
-        {
-            if (string.IsNullOrEmpty(fullPath))
-                return null;
-
-            if (inactiveTextMeshPathCache.TryGetValue(fullPath, out TextMesh cachedTextMesh))
-            {
-                if (cachedTextMesh != null && cachedTextMesh.gameObject != null)
-                    return cachedTextMesh;
-
-                inactiveTextMeshPathCache.Remove(fullPath);
-            }
-
-            TextMesh[] allTextMeshes = Resources.FindObjectsOfTypeAll<TextMesh>();
-            if (allTextMeshes == null)
-                return null;
-
-            for (int i = 0; i < allTextMeshes.Length; i++)
-            {
-                TextMesh textMesh = allTextMeshes[i];
-                if (textMesh == null || textMesh.gameObject == null)
-                    continue;
-
-                string path = GetGameObjectPath(textMesh.gameObject);
-                if (path == fullPath)
-                {
-                    inactiveTextMeshPathCache[fullPath] = textMesh;
-                    return textMesh;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
         /// Find PlayMakerFSM by object path + FSM name, including inactive objects.
         /// Uses a cache and falls back to Resources.FindObjectsOfTypeAll when needed.
         /// </summary>
@@ -193,7 +154,6 @@ namespace MWC_Localization_Core
         {
             pathCache.Clear();
             gameObjectFindCache.Clear();
-            inactiveTextMeshPathCache.Clear();
             inactiveFsmPathNameCache.Clear();
         }
     }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -218,7 +218,6 @@ namespace MWC_Localization_Core
                     lateUpdateHandlerObject = null;
                     lateUpdateHandler = null;
                 }
-                
                 CoreConsole.Print($"[{Name}] Scene changed to '{currentScene}' - cleared caches");
             }
 
@@ -511,6 +510,11 @@ namespace MWC_Localization_Core
 
             if (Application.loadedLevelName == "MainMenu" || Application.loadedLevelName == "GAME")
             {
+                if (fsmTextHookObject != null)
+                {
+                    Object.Destroy(fsmTextHookObject);
+                    fsmTextHookObject = null;
+                }
                 InitializeFsmTextHook();
             }
 

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -170,7 +170,6 @@ namespace MWC_Localization_Core
             lateUpdateHandlerObject = new GameObject("MWC_LateUpdateHandler");
             lateUpdateHandler = lateUpdateHandlerObject.AddComponent<LateUpdateHandler>();
             lateUpdateHandler.Initialize(
-                translator, 
                 textMeshMonitor, 
                 teletextHandler, 
                 arrayListHandler, 

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -1,95 +1,85 @@
 namespace MWC_Localization_Core
 {
     /// <summary>
-    /// Defines how frequently a TextMesh should be monitored for changes
+    /// Defines how frequently a TextMesh should be monitored for changes.
     /// </summary>
     public enum MonitoringStrategy
     {
         /// <summary>
-        /// Translate once during initial scene scan, then forget
-        /// Use for: Static UI elements that never change
+        /// Translate once during the initial scene scan, then stop monitoring.
+        /// Use for static UI elements that never change.
         /// </summary>
         TranslateOnce,
 
         /// <summary>
-        /// Monitor every frame without throttling (highest priority)
-        /// Use for: Interaction prompts, subtitles, critical realtime UI
-        /// Example: "Press E to interact", subtitle text
+        /// Monitor every frame without throttling.
+        /// Use for interaction prompts, subtitles, and other critical real-time UI.
         /// </summary>
         EveryFrame,
 
         /// <summary>
-        /// Monitor at 10 FPS (0.1s intervals) for responsive UI
-        /// Use for: Active HUD elements that update frequently
-        /// Example: Hunger, stress, temperature displays
+        /// Monitor at a fast polling interval for responsive UI.
+        /// Use for active HUD elements that update frequently.
         /// </summary>
         FastPolling,
 
         /// <summary>
-        /// Monitor at 1 FPS (1.0s intervals) for less critical content
-        /// Use for: Teletext, FSM-generated content, weather displays
-        /// Example: TV text, bottomlines, weather forecasts
+        /// Monitor at a slow polling interval for less critical content.
+        /// Use for teletext, FSM-generated content, and weather displays.
         /// </summary>
         SlowPolling,
 
         /// <summary>
-        /// Keep checking even after translation (for regenerated content)
-        /// Use for: Magazine text that game constantly regenerates
-        /// Example: Yellow Pages random words
+        /// Keep checking even after translation for content that is frequently rebuilt.
+        /// Use for magazine text and similar regenerated content.
         /// </summary>
         Persistent,
 
         /// <summary>
-        /// Only translate when GameObject becomes active in hierarchy
-        /// Use for: UI panels that are shown/hidden
-        /// Example: Menus, popup dialogs
+        /// Translate only when a GameObject becomes active in the hierarchy.
+        /// Use for menus, dialogs, and other show/hide UI panels.
         /// </summary>
         OnVisibilityChange,
 
         /// <summary>
-        /// Translate once, but when its textMesh becomes available (delayed)
-        /// Use for: TextMeshes created dynamically after initial scan
+        /// Translate once when the TextMesh becomes available later.
+        /// Use for dynamically created TextMeshes that appear after the initial scan.
+        /// </summary>
         LateTranslateOnce,
     }
 
     /// <summary>
-    /// Defines which translation method to use
+    /// Defines which translation method to use.
     /// </summary>
     public enum TranslationMode
     {
         /// <summary>
-        /// Simple dictionary lookup: "BEER" -> "맥주"
+        /// Simple dictionary lookup for exact text keys.
         /// </summary>
         SimpleLookup,
 
         /// <summary>
-        /// Pattern matching with {0}, {1} placeholders
-        /// Example: "pakkasta {0} astetta" -> extract variable -> "영하 {0}도"
+        /// Pattern matching with {0}, {1}, and similar placeholders.
         /// </summary>
         FsmPattern,
 
         /// <summary>
-        /// Regular expression extraction and replacement
-        /// Example: "PRICE TOTAL: 0.00 MK" -> extract "0.00" -> "가격: 0.00 MK"
+        /// Regular expression extraction and replacement.
         /// </summary>
         RegexExtract,
 
         /// <summary>
-        /// Split by comma and translate each word independently
-        /// Example: "bucket, oil, hydraulic" -> "양동이, 오일, 유압"
+        /// Split by comma and translate each item independently.
         /// </summary>
         CommaSeparated,
 
         /// <summary>
-        /// Use custom handler function for complex logic
-        /// Example: Magazine price/phone lines with special formatting
+        /// Use a custom handler for more complex translation logic.
         /// </summary>
         CustomHandler,
 
         /// <summary>
-        /// Pattern matching with {0}, {1} placeholders AND parameter translation
-        /// Example: "Hello! I would like to order a taxi to {0}." 
-        /// Extracts "Futufon", translates it to Korean, inserts into Korean template
+        /// Pattern matching with placeholders plus translation of extracted parameters.
         /// </summary>
         FsmPatternWithTranslation
     }

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -4,13 +4,11 @@ namespace MWC_Localization_Core
 {
     /// <summary>
     /// Manages scene transitions and translation flags
-    /// Consolidates hasTranslatedSplashScreen, hasTranslatedMainMenu, hasTranslatedGameScene logic
+    /// Tracks whether supported scenes have already received their initial translation pass
     /// </summary>
     public class SceneTranslationManager
     {
-        
         // Scene translation states
-        private bool hasTranslatedSplashScreen = false;
         private bool hasTranslatedMainMenu = false;
         private bool hasTranslatedGameScene = false;
         
@@ -29,9 +27,6 @@ namespace MWC_Localization_Core
         {
             switch (sceneName)
             {
-                case "SplashScreen":
-                    return !hasTranslatedSplashScreen;
-                    
                 case "MainMenu":
                     return !hasTranslatedMainMenu;
                     
@@ -50,11 +45,6 @@ namespace MWC_Localization_Core
         {
             switch (sceneName)
             {
-                case "SplashScreen":
-                    hasTranslatedSplashScreen = true;
-                    CoreConsole.Print("[SceneTranslationManager] Splash Screen marked as translated");
-                    break;
-                    
                 case "MainMenu":
                     hasTranslatedMainMenu = true;
                     CoreConsole.Print("[SceneTranslationManager] Main Menu marked as translated");
@@ -108,41 +98,8 @@ namespace MWC_Localization_Core
         /// </summary>
         public void ResetAll()
         {
-            hasTranslatedSplashScreen = false;
             hasTranslatedMainMenu = false;
             hasTranslatedGameScene = false;
-        }
-
-        /// <summary>
-        /// Get current scene name
-        /// </summary>
-        public string GetCurrentScene()
-        {
-            return currentScene;
-        }
-
-        /// <summary>
-        /// Get previous scene name
-        /// </summary>
-        public string GetPreviousScene()
-        {
-            return previousScene;
-        }
-
-        /// <summary>
-        /// Check if currently in main menu
-        /// </summary>
-        public bool IsInMainMenu()
-        {
-            return currentScene == "MainMenu";
-        }
-
-        /// <summary>
-        /// Check if currently in game
-        /// </summary>
-        public bool IsInGame()
-        {
-            return currentScene == "GAME";
         }
 
         /// <summary>
@@ -152,9 +109,6 @@ namespace MWC_Localization_Core
         {
             switch (sceneName)
             {
-                case "SplashScreen":
-                    return hasTranslatedSplashScreen;
-                    
                 case "MainMenu":
                     return hasTranslatedMainMenu;
                     

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -16,9 +16,10 @@ namespace MWC_Localization_Core
         private PatternMatcher patternMatcher;
         private LocalizationConfig config;
         private Dictionary<int, string> appliedFontCache = new Dictionary<int, string>();
+        private Dictionary<int, Texture> appliedRuntimeTextureCache = new Dictionary<int, Texture>();
         private Dictionary<string, Font> fontNameToFont;  // Reverse lookup: font.name -> Font
 
-        private List<string> ExcludedPath = new List<string>
+        private static readonly string[] ExcludedPath = new string[]
         {
             "HOMENEW/Functions/FunctionsDisable/Stereos/Player/Screen/Settings/Bass/LCD",
             "CARPARTS/VINPlate",
@@ -123,12 +124,21 @@ namespace MWC_Localization_Core
                 {
                     if (IsRuntimeSensitiveTvPath(path))
                     {
-                        // Legacy-safe path: keep runtime material/shader, only swap atlas texture.
-                        Material runtimeMaterial = renderer.material;
                         Texture targetMainTexture = customFont.material.mainTexture;
-                        if (runtimeMaterial != null && targetMainTexture != null && runtimeMaterial.mainTexture != targetMainTexture)
+                        int rendererInstanceID = renderer.GetInstanceID();
+                        bool needsTextureApply = !appliedRuntimeTextureCache.TryGetValue(rendererInstanceID, out Texture cachedTexture)
+                            || cachedTexture != targetMainTexture;
+
+                        if (needsTextureApply && targetMainTexture != null)
                         {
-                            runtimeMaterial.mainTexture = targetMainTexture;
+                            // Keep the runtime material/shader setup intact and swap only the atlas texture.
+                            Material runtimeMaterial = renderer.material;
+                            if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
+                            {
+                                runtimeMaterial.mainTexture = targetMainTexture;
+                            }
+
+                            appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
                         }
                     }
                     else
@@ -307,6 +317,7 @@ namespace MWC_Localization_Core
         public void ClearRuntimeCaches()
         {
             appliedFontCache.Clear();
+            appliedRuntimeTextureCache.Clear();
         }
     }
 }

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -129,7 +129,7 @@ namespace MWC_Localization_Core
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/HEADER/Texts/Status", MonitoringStrategy.FastPolling);
 
             // Teletext/FSM displays are primarily translated at array/FSM source level.
-            // Use one-shot late registration to avoid scanning large TV trees every second.
+            // Use one-shot late registration to avoid rescanning large TV trees continuously.
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/PAGES", MonitoringStrategy.LateTranslateOnce);
             AddPathRule("Systems/TV/TVGraphics/CHAT/Generated", MonitoringStrategy.LateTranslateOnce);
 
@@ -150,32 +150,6 @@ namespace MWC_Localization_Core
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
         {
             pathRules[pathPattern] = strategy;
-        }
-
-        /// <summary>
-        /// Determine monitoring strategy for a given path
-        /// Matches most specific (longest) rule first to avoid ambiguity
-        /// </summary>
-        public MonitoringStrategy DetermineStrategy(string path)
-        {
-            string longestMatch = null;
-            MonitoringStrategy matchedStrategy = MonitoringStrategy.TranslateOnce;
-
-            // Find the longest (most specific) matching rule
-            foreach (var rule in pathRules)
-            {
-                if (path.Contains(rule.Key))
-                {
-                    // Use longest match (most specific)
-                    if (longestMatch == null || rule.Key.Length > longestMatch.Length)
-                    {
-                        longestMatch = rule.Key;
-                        matchedStrategy = rule.Value;
-                    }
-                }
-            }
-
-            return matchedStrategy;
         }
 
         /// <summary>
@@ -282,28 +256,6 @@ namespace MWC_Localization_Core
                 registeredCount++;
             }
             return registeredCount;
-        }
-
-        /// <summary>
-        /// Unregister a TextMesh from monitoring by path
-        /// Removes all TextMesh instances at the given path
-        /// </summary>
-        public void Unregister(string path)
-        {
-            HashSet<int> instanceIDs;
-            if (path == null || !pathToInstances.TryGetValue(path, out instanceIDs))
-                return;
-
-            foreach (int instanceID in instanceIDs)
-            {
-                TextMeshEntry entry;
-                if (!instanceEntries.TryGetValue(instanceID, out entry))
-                    continue;
-                strategyGroups[entry.Strategy].Remove(instanceID);
-                instanceEntries.Remove(instanceID);
-            }
-            
-            pathToInstances.Remove(path);
         }
 
         /// <summary>


### PR DESCRIPTION
- reduce runtime polling cost in FSM translation hook
- cache processed FSM targets and teletext weather FSM instances
- lower frequency of expensive FSM rescans to improve frametime stability
- avoid repeated runtime material texture updates for TV and teletext text
- tune monitoring intervals to reduce recurring translation overhead
- ensure FSM hook lifecycle is recreated correctly on reload without breaking menu initialization
- remove dead and legacy code from scene, monitor, array and utility helpers
- clean up outdated comments and legacy wording across the project
- rewrite MonitoringStrategy comments to remove corrupted encoding and improve clarit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FSM hook reload behavior and ensured teardown/reinitialization during translation reloads.
  * Reduced redundant translation reapplications via de-duplication, lowering wasted work.

* **Refactor**
  * Removed legacy splash-screen translation handling.
  * Eliminated some background caching/lookup mechanisms and unused dependencies.
  * Adjusted polling/monitoring intervals and lifecycle polling to reduce CPU churn.

* **Documentation**
  * Clarified monitoring/translation strategy comments for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->