### PR TITLE
feat: patch CONLINE chat FSM status translation

### DIFF
--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -51,7 +51,8 @@ namespace MWC_Localization_Core
             PosTyper,
             TeletextBuildStringPattern,
             TeletextWeatherUpdaterTokens,
-            UnemployPaperButtonVariables
+            UnemployPaperButtonVariables,
+            ConlineChatStatus
         }
 
         private sealed class FsmStrategyTarget
@@ -202,6 +203,20 @@ namespace MWC_Localization_Core
             return targets.ToArray();
         }
 
+        private static readonly FsmStrategyTarget[] GameConlineTargets = new FsmStrategyTarget[]
+        {
+            new FsmStrategyTarget(
+                "COMPUTER/SYSTEM/TELEBBS/CONLINE/CHAT",
+                "Type",
+                FsmStrategyType.ConlineChatStatus,
+                "GAME CONLINE",
+                "CONLINE_CHAT_READY",
+                "[FsmTextHook] CONLINE chat FSM targets are ready.",
+                null,
+                -1)
+        };
+
+
         public void Initialize(Dictionary<string, string> translations, GameObject hostObject, string[] patternFiles)
         {
             this.translations = translations;
@@ -265,6 +280,7 @@ namespace MWC_Localization_Core
             anyChanged |= TryApplyGameTeletextBottomlineFsmTranslations();
             anyChanged |= TryApplyGameTeletextWeatherUpdaterFsmTranslations();
             anyChanged |= TryApplyGameUnemployPaperFsmTranslations();
+            anyChanged |= TryApplyGameConlineChatFsmTranslations();
 
             if (anyChanged)
             {
@@ -380,6 +396,22 @@ namespace MWC_Localization_Core
             return anyChanged || hasAnyTarget;
         }
 
+
+        private bool TryApplyGameConlineChatFsmTranslations()
+        {
+            bool anyChanged = false;
+            bool hasAnyTarget = false;
+
+            ApplyStrategyTargets(GameConlineTargets, ref anyChanged, ref hasAnyTarget);
+
+            if (anyChanged)
+            {
+                appliedTarget = "GAME CONLINE";
+            }
+
+            return anyChanged || hasAnyTarget;
+        }
+
         private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged, ref bool hasAnyTarget)
         {
             if (targets == null || targets.Length == 0)
@@ -449,6 +481,11 @@ namespace MWC_Localization_Core
 
                 case FsmStrategyType.TeletextWeatherUpdaterTokens:
                     ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
+                    break;
+
+                case FsmStrategyType.ConlineChatStatus:
+                    anyChanged |= ApplyConlineChatStatusTranslations(fsm);
+                    hasAnyTarget = true;
                     break;
 
                 case FsmStrategyType.UnemployPaperButtonVariables:
@@ -1044,6 +1081,61 @@ namespace MWC_Localization_Core
                 return value;
 
             return fallback;
+        }
+
+
+        private bool ApplyConlineChatStatusTranslations(PlayMakerFSM fsm)
+        {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
+            bool changed = false;
+
+            changed |= ApplyConlineNestedTranslation(fsm, "Download", 1);
+            changed |= ApplyConlineNestedTranslation(fsm, "Fail", 0);
+
+            return changed;
+        }
+
+        private bool ApplyConlineNestedTranslation(PlayMakerFSM fsm, string stateName, int actionIndex)
+        {
+            HutongGames.PlayMaker.FsmState state = null;
+            for (int i = 0; i < fsm.FsmStates.Length; i++)
+            {
+                if (fsm.FsmStates[i] != null && fsm.FsmStates[i].Name == stateName)
+                {
+                    state = fsm.FsmStates[i];
+                    break;
+                }
+            }
+
+            if (state == null || state.Actions == null || actionIndex < 0 || actionIndex >= state.Actions.Length)
+                return false;
+
+            object action = state.Actions[actionIndex];
+            if (action == null)
+                return false;
+
+            var targetProperty = GetCachedField(action.GetType(), "targetProperty")?.GetValue(action);
+            if (targetProperty == null)
+                return false;
+
+            var fsmString = GetCachedField(targetProperty.GetType(), "StringParameter")?
+                .GetValue(targetProperty) as HutongGames.PlayMaker.FsmString;
+
+            if (fsmString == null || string.IsNullOrEmpty(fsmString.Value))
+                return false;
+
+            string original = fsmString.Value;
+            string translated = GetTranslation(original, original);
+
+            if (translated != original)
+            {
+                fsmString.Value = translated;
+                return true;
+            }
+
+            return false;
         }
 
         private void Cleanup()

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -208,19 +208,15 @@ namespace MWC_Localization_Core
                 {
                     if (!mainMenuTranslated)
                     {
-<<<<<<< Updated upstream
-
-=======
                         if (TryApplyMainMenuTranslations())
                         {
                             mainMenuTranslated = true;
-                            appliedTarget = "MainMenu";
+                            string appliedTarget = "MainMenu";
                             string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
                             CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
                             Cleanup();
                             yield break;
                         }
->>>>>>> Stashed changes
                     }
 
                     yield return BootstrapPollDelay;

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -19,6 +19,7 @@ namespace MWC_Localization_Core
         private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
         private float lastEnnusteDataFsmScanTime = -10f;
+        private bool mainMenuTranslated = false;  // Ensure main menu only translates once
 
         private static readonly WaitForSeconds BootstrapPollDelay = new WaitForSeconds(0.5f);
         private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(3.0f);
@@ -205,9 +206,21 @@ namespace MWC_Localization_Core
 
                 if (currentScene == "MainMenu")
                 {
-                    if (TryApplyMainMenuTranslations())
+                    if (!mainMenuTranslated)
                     {
+<<<<<<< Updated upstream
 
+=======
+                        if (TryApplyMainMenuTranslations())
+                        {
+                            mainMenuTranslated = true;
+                            appliedTarget = "MainMenu";
+                            string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
+                            CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
+                            Cleanup();
+                            yield break;
+                        }
+>>>>>>> Stashed changes
                     }
 
                     yield return BootstrapPollDelay;

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -1099,6 +1099,9 @@ namespace MWC_Localization_Core
 
         private bool ApplyConlineNestedTranslation(PlayMakerFSM fsm, string stateName, int actionIndex)
         {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
             HutongGames.PlayMaker.FsmState state = null;
             for (int i = 0; i < fsm.FsmStates.Length; i++)
             {

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -15,8 +15,6 @@ namespace MWC_Localization_Core
         private Dictionary<string, string> translations;
         private GameObject hostObject;
         private PatternMatcher patternMatcher;
-        private string appliedTarget;
-        private HashSet<string> loggedReadyTargets = new HashSet<string>();
         private HashSet<string> completedStrategyTargets = new HashSet<string>();
         private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
@@ -60,9 +58,6 @@ namespace MWC_Localization_Core
             public string ObjectPath;
             public string FsmName;
             public FsmStrategyType Strategy;
-            public string AppliedLabel;
-            public string ReadyLogKey;
-            public string ReadyLogMessage;
             public string StateName;
             public int ActionIndex;
 
@@ -70,18 +65,12 @@ namespace MWC_Localization_Core
                 string objectPath,
                 string fsmName,
                 FsmStrategyType strategy,
-                string appliedLabel,
-                string readyLogKey,
-                string readyLogMessage,
                 string stateName,
                 int actionIndex)
             {
                 ObjectPath = objectPath;
                 FsmName = fsmName;
                 Strategy = strategy;
-                AppliedLabel = appliedLabel;
-                ReadyLogKey = readyLogKey;
-                ReadyLogMessage = readyLogMessage;
                 StateName = stateName;
                 ActionIndex = actionIndex;
             }
@@ -96,18 +85,12 @@ namespace MWC_Localization_Core
                 "COMPUTER/SYSTEM/POS/BootSequence",
                 "Use",
                 FsmStrategyType.PosUse,
-                "GAME POS",
-                "POS_USE_READY",
-                "[FsmTextHook] Use FSM is initialized and ready.",
                 null,
                 -1),
             new FsmStrategyTarget(
                 "COMPUTER/SYSTEM/POS/Command",
                 "Typer",
                 FsmStrategyType.PosTyper,
-                "GAME POS",
-                "POS_TYPER_READY",
-                "[FsmTextHook] Typer FSM is initialized and ready.",
                 null,
                 -1)
         };
@@ -118,36 +101,24 @@ namespace MWC_Localization_Core
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/240/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/241/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/302/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/302/Texts/Data 1/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 3)
         };
@@ -160,18 +131,12 @@ namespace MWC_Localization_Core
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Nyt",
                 "Logic",
                 FsmStrategyType.TeletextWeatherUpdaterTokens,
-                "GAME Teletext Weather",
-                "TTX_WX_READY",
-                "[FsmTextHook] Teletext weather updater FSM targets are ready.",
                 null,
                 -1),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Ennuste",
                 "Logic",
                 FsmStrategyType.TeletextWeatherUpdaterTokens,
-                "GAME Teletext Weather",
-                "TTX_WX_READY",
-                "[FsmTextHook] Teletext weather updater FSM targets are ready.",
                 null,
                 -1)
         };
@@ -192,9 +157,6 @@ namespace MWC_Localization_Core
                         path,
                         "Button",
                         FsmStrategyType.UnemployPaperButtonVariables,
-                        "GAME UnemployPaper",
-                        "UNEMPLOY_READY",
-                        "[FsmTextHook] UnemployPaper Button FSM targets are ready.",
                         null,
                         -1));
                 }
@@ -209,9 +171,6 @@ namespace MWC_Localization_Core
                 "COMPUTER/SYSTEM/TELEBBS/CONLINE/CHAT",
                 "Type",
                 FsmStrategyType.ConlineChatStatus,
-                "GAME CONLINE",
-                "CONLINE_CHAT_READY",
-                "[FsmTextHook] CONLINE chat FSM targets are ready.",
                 null,
                 -1)
         };
@@ -248,11 +207,7 @@ namespace MWC_Localization_Core
                 {
                     if (TryApplyMainMenuTranslations())
                     {
-                        appliedTarget = "MainMenu";
-                        string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
-                        CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
-                        Cleanup();
-                        yield break;
+
                     }
 
                     yield return BootstrapPollDelay;
@@ -284,8 +239,7 @@ namespace MWC_Localization_Core
 
             if (anyChanged)
             {
-                string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "GAME" : appliedTarget;
-                CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
+                // FSM translations applied
             }
         }
 
@@ -327,12 +281,6 @@ namespace MWC_Localization_Core
             bool anyChanged = false;
             bool hasAnyTarget = false;
             ApplyStrategyTargets(GamePosTargets, ref anyChanged, ref hasAnyTarget);
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME POS";
-            }
-
             return anyChanged || hasAnyTarget;
         }
 
@@ -341,12 +289,6 @@ namespace MWC_Localization_Core
             bool anyChanged = false;
             bool hasAnyTarget = false;
             ApplyStrategyTargets(GameTeletextTargets, ref anyChanged, ref hasAnyTarget);
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME Teletext Bottomline";
-            }
-
             return anyChanged || hasAnyTarget;
         }
 
@@ -368,14 +310,8 @@ namespace MWC_Localization_Core
                 if (completedEnnusteFsmInstances.Contains(instanceID))
                     continue;
 
-                LogReadyOnce("TTX_WX_READY", "[FsmTextHook] Teletext weather updater FSM targets are ready.");
                 ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
                 completedEnnusteFsmInstances.Add(instanceID);
-            }
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME Teletext Weather";
             }
 
             return anyChanged || hasAnyTarget;
@@ -387,12 +323,6 @@ namespace MWC_Localization_Core
             bool hasAnyTarget = false;
 
             ApplyStrategyTargets(GameUnemployPaperTargets, ref anyChanged, ref hasAnyTarget);
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME UnemployPaper";
-            }
-
             return anyChanged || hasAnyTarget;
         }
 
@@ -403,12 +333,6 @@ namespace MWC_Localization_Core
             bool hasAnyTarget = false;
 
             ApplyStrategyTargets(GameConlineTargets, ref anyChanged, ref hasAnyTarget);
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME CONLINE";
-            }
-
             return anyChanged || hasAnyTarget;
         }
 
@@ -431,7 +355,6 @@ namespace MWC_Localization_Core
                 if (!IsFsmReady(fsm))
                     continue;
 
-                LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
                 ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
                 completedStrategyTargets.Add(targetKey);
             }
@@ -493,23 +416,6 @@ namespace MWC_Localization_Core
                     hasAnyTarget = true;
                     break;
             }
-
-            if (anyChanged && !string.IsNullOrEmpty(target.AppliedLabel))
-            {
-                appliedTarget = target.AppliedLabel;
-            }
-        }
-
-        private void LogReadyOnce(string key, string message)
-        {
-            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(message))
-                return;
-
-            if (loggedReadyTargets.Contains(key))
-                return;
-
-            loggedReadyTargets.Add(key);
-            CoreConsole.Print(message);
         }
 
         private bool IsFsmReady(PlayMakerFSM fsm)


### PR DESCRIPTION
- add direct FSM translation for CONLINE chat status messages
- translate "Sending..." and "Sending failed!" at the source FSM
- avoid visual text retranslation to prevent flickering
- keep localization compatibility through GetTranslation()
- preserve stable frametime during CONLINE chat updates

Bug fix: https://github.com/potatosalad775/MWC_Localization_Core/issues/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation support for the CONLINE CHAT game system, including nested in-action text translations.

* **Bug Fixes**
  * Improved detection and application of nested text-parameter translations within CONLINE CHAT flows.
  * Reduced noisy output by removing per-target readiness logs and suppressing the overall "translations applied" message.
  * Main-menu translations now run only once to prevent repeated reapplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->