### PR TITLE
refactor: unify translation parsing and fix chat TV font rendering

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -44,6 +44,10 @@ namespace MWC_Localization_Core
         private Dictionary<string, PlayMakerArrayListProxy> arrayProxyCache 
             = new Dictionary<string, PlayMakerArrayListProxy>();
 
+        // Cache for GetComponentsInChildren results to avoid repeated expensive calls
+        private Dictionary<string, TextMesh[]> textMeshCache
+            = new Dictionary<string, TextMesh[]>();
+
         public ArrayListProxyHandler(
             Dictionary<string, string> translations, 
             MagazineTextHandler magazineHandler, 
@@ -100,6 +104,7 @@ namespace MWC_Localization_Core
             arrayProxyCache.Clear();
             fontAppliedInstances.Clear();
             completedParentPaths.Clear();
+            textMeshCache.Clear();
         }
 
         public void Reset()
@@ -108,6 +113,7 @@ namespace MWC_Localization_Core
             arrayProxyCache.Clear();
             fontAppliedInstances.Clear();
             completedParentPaths.Clear();
+            textMeshCache.Clear();
         }
 
         // Translate all configured arrays (call once per scene)
@@ -301,7 +307,13 @@ namespace MWC_Localization_Core
                     continue; // Not loaded yet - will try again later
 
                 // Get all TextMesh components under this parent and apply fonts to ALL of them
-                TextMesh[] textMeshes = parent.GetComponentsInChildren<TextMesh>(true);
+                // Cache results to avoid expensive GetComponentsInChildren calls every frame
+                TextMesh[] textMeshes;
+                if (!textMeshCache.TryGetValue(parentPath, out textMeshes))
+                {
+                    textMeshes = parent.GetComponentsInChildren<TextMesh>(true);
+                    textMeshCache[parentPath] = textMeshes;
+                }
                 
                 bool anyNewFonts = false;
 

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -262,15 +262,28 @@ namespace MWC_Localization_Core
             return null;
         }
 
-        // Apply localized fonts to TextMesh components displaying array data
-        // Call this once during scene initialization, then periodically until all paths are complete
         public int ApplyFontsToArrayElements()
         {
             if (translator == null)
                 return 0;
 
-            // Early exit if all parent paths have been fully processed
-            if (completedParentPaths.Count >= parentSearchPaths.Count)
+            // Count completable paths (excluding dynamic ones that never mark complete)
+            int completablePathCount = 0;
+            foreach (string path in parentSearchPaths)
+            {
+                if (!dynamicParentPaths.Contains(path))
+                    completablePathCount++;
+            }
+
+            // Early exit if all completable parent paths have been fully processed
+            int completedNonDynamicCount = 0;
+            foreach (string path in completedParentPaths)
+            {
+                if (!dynamicParentPaths.Contains(path))
+                    completedNonDynamicCount++;
+            }
+            
+            if (completablePathCount > 0 && completedNonDynamicCount >= completablePathCount)
                 return 0;
 
             int fontsApplied = 0;
@@ -279,7 +292,8 @@ namespace MWC_Localization_Core
             foreach (string parentPath in parentSearchPaths)
             {
                 // Skip already completed parent paths (huge performance boost)
-                if (completedParentPaths.Contains(parentPath))
+                // But always process dynamic paths as they're never marked complete
+                if (completedParentPaths.Contains(parentPath) && !dynamicParentPaths.Contains(parentPath))
                     continue;
 
                 GameObject parent = MLCUtils.FindGameObjectCached(parentPath);
@@ -330,7 +344,7 @@ namespace MWC_Localization_Core
 
             if (fontsApplied > 0)
             {
-                CoreConsole.Print($"[ArrayListProxyHandler] Applied Custom font to {fontsApplied} TextMesh components ({completedParentPaths.Count}/{parentSearchPaths.Count} paths complete)");
+                CoreConsole.Print($"[ArrayListProxyHandler] Applied Custom font to {fontsApplied} TextMesh components ({completedNonDynamicCount}/{completablePathCount} paths complete)");
             }
 
             return fontsApplied;

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -82,7 +82,8 @@ namespace MWC_Localization_Core
                 "Sheets/YellowPagesMagazine/Page1/Row2",  // Magazine Page 1 Row 2
                 "Sheets/YellowPagesMagazine/Page2/Row3",  // Magazine Page 2 Row 3
                 "Sheets/YellowPagesMagazine/Page2/Row4",  // Magazine Page 2 Row 4
-                // Add more parent paths as needed
+                "Systems/TV/TVGraphics/CHAT/Generated/Lines",  // Chat TV messages
+                "Systems/TV/TVGraphics/CHAT/Day/Time"  // Chat TV Day/Time display
             };
         }
 

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -305,12 +305,17 @@ namespace MWC_Localization_Core
                     }
                 }
 
-                // Mark this parent path as complete if we found the parent and processed all its TextMeshes
-                // (If anyNewFonts is false, it means all TextMeshes were already processed)
-                if (!anyNewFonts)
+                // IMPORTANT: Don't mark as complete just because no new fonts were found this call.
+                // TextMeshes may not exist yet (lazy-loaded by game).
+                // Only mark complete if we found the parent and it had TextMeshes to process.
+                // This ensures we retry when child objects are created at runtime.
+                if (textMeshes.Length > 0 && !anyNewFonts)
                 {
+                    // Parent exists and has TextMeshes but no new fonts - truly complete
                     completedParentPaths.Add(parentPath);
                 }
+                // If textMeshes.Length == 0: parent exists but has no children yet, retry later
+                // If anyNewFonts == true: we processed something, keep trying for more
             }
 
             if (fontsApplied > 0)

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -33,6 +33,13 @@ namespace MWC_Localization_Core
         // Apply fonts to ALL TextMeshes under these paths
         private List<string> parentSearchPaths;
         
+        // Known dynamic roots that may gain TextMesh children at runtime - never mark these complete
+        private static readonly HashSet<string> dynamicParentPaths = new HashSet<string>
+        {
+            "Systems/TV/TVGraphics/CHAT/Generated/Lines",
+            "Systems/TV/TVGraphics/CHAT/Day/Time"
+        };
+        
         // Cache for array proxies to avoid repeated lookups
         private Dictionary<string, PlayMakerArrayListProxy> arrayProxyCache 
             = new Dictionary<string, PlayMakerArrayListProxy>();
@@ -309,13 +316,16 @@ namespace MWC_Localization_Core
                 // TextMeshes may not exist yet (lazy-loaded by game).
                 // Only mark complete if we found the parent and it had TextMeshes to process.
                 // This ensures we retry when child objects are created at runtime.
-                if (textMeshes.Length > 0 && !anyNewFonts)
+                // Never mark dynamic paths as complete since they may gain children later.
+                if (textMeshes.Length > 0 && !anyNewFonts && !dynamicParentPaths.Contains(parentPath))
                 {
                     // Parent exists and has TextMeshes but no new fonts - truly complete
+                    // (unless it's a known dynamic path that may gain children later)
                     completedParentPaths.Add(parentPath);
                 }
                 // If textMeshes.Length == 0: parent exists but has no children yet, retry later
                 // If anyNewFonts == true: we processed something, keep trying for more
+                // If dynamic path: never mark complete to catch late-added TextMeshes
             }
 
             if (fontsApplied > 0)

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -201,7 +201,7 @@ namespace MWC_Localization_Core
                 }
             }
 
-            StartCoroutine(ApplyWhenReady());
+            applyWhenReadyCoroutine = StartCoroutine(ApplyWhenReady());
         }
 
         private IEnumerator ApplyWhenReady()
@@ -359,8 +359,16 @@ namespace MWC_Localization_Core
                 if (!IsFsmReady(fsm))
                     continue;
 
-                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
-                completedStrategyTargets.Add(targetKey);
+                // Track if this strategy makes any changes
+                bool strategyChanged = false;
+                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget, out strategyChanged);
+                
+                // Only mark as complete if the strategy actually made a change
+                // This ensures ConlineChatStatus and similar one-shot strategies retry until they succeed
+                if (strategyChanged || target.Strategy != FsmStrategyType.ConlineChatStatus)
+                {
+                    completedStrategyTargets.Add(targetKey);
+                }
             }
         }
 
@@ -369,10 +377,13 @@ namespace MWC_Localization_Core
             return target.ObjectPath + "|" + target.FsmName + "|" + target.Strategy.ToString() + "|" + target.StateName + "|" + target.ActionIndex.ToString();
         }
 
-        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
+        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget, out bool strategyChanged)
         {
+            strategyChanged = false;
             if (target == null || fsm == null)
                 return;
+
+            bool beforeChanged = anyChanged;
 
             switch (target.Strategy)
             {
@@ -426,6 +437,9 @@ namespace MWC_Localization_Core
                     hasAnyTarget = true;
                     break;
             }
+            
+            // Set strategyChanged to indicate if this strategy made any modifications
+            strategyChanged = (anyChanged != beforeChanged);
         }
 
         private bool IsFsmReady(PlayMakerFSM fsm)

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -14,6 +14,7 @@ namespace MWC_Localization_Core
     {
         private Dictionary<string, string> translations;
         private GameObject hostObject;
+        private Coroutine applyWhenReadyCoroutine;
         private PatternMatcher patternMatcher;
         private HashSet<string> completedStrategyTargets = new HashSet<string>();
         private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
@@ -854,7 +855,6 @@ namespace MWC_Localization_Core
             }
 
             string result = sb.ToString();
-            sb.Length = 0;  // NET 3.5 compatible: reset StringBuilder for reuse
             return result;
         }
 
@@ -1080,8 +1080,18 @@ namespace MWC_Localization_Core
 
         private void OnDestroy()
         {
-            StopCoroutine(ApplyWhenReady());
-            hostObject = null;
+            // Stop the actual running coroutine using the stored reference
+            if (applyWhenReadyCoroutine != null)
+            {
+                StopCoroutine(applyWhenReadyCoroutine);
+                applyWhenReadyCoroutine = null;
+            }
+            
+            if (hostObject != null)
+            {
+                Object.Destroy(hostObject);
+                hostObject = null;
+            }
         }
     }
 }

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -1106,6 +1106,9 @@ namespace MWC_Localization_Core
                 Object.Destroy(hostObject);
                 hostObject = null;
             }
+
+            // Clear static reflection cache to prevent memory bloat from accumulated FieldInfo objects
+            reflectionCache.Clear();
         }
     }
 }

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -15,8 +15,6 @@ namespace MWC_Localization_Core
         private Dictionary<string, string> translations;
         private GameObject hostObject;
         private PatternMatcher patternMatcher;
-        private string appliedTarget;
-        private HashSet<string> loggedReadyTargets = new HashSet<string>();
         private HashSet<string> completedStrategyTargets = new HashSet<string>();
         private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
@@ -50,8 +48,10 @@ namespace MWC_Localization_Core
             PosUse,
             PosTyper,
             TeletextBuildStringPattern,
+            TeletextBuildStringSimple,
             TeletextWeatherUpdaterTokens,
-            UnemployPaperButtonVariables
+            UnemployPaperButtonVariables,
+            ConlineChatStatus
         }
 
         private sealed class FsmStrategyTarget
@@ -59,9 +59,6 @@ namespace MWC_Localization_Core
             public string ObjectPath;
             public string FsmName;
             public FsmStrategyType Strategy;
-            public string AppliedLabel;
-            public string ReadyLogKey;
-            public string ReadyLogMessage;
             public string StateName;
             public int ActionIndex;
 
@@ -69,18 +66,12 @@ namespace MWC_Localization_Core
                 string objectPath,
                 string fsmName,
                 FsmStrategyType strategy,
-                string appliedLabel,
-                string readyLogKey,
-                string readyLogMessage,
                 string stateName,
                 int actionIndex)
             {
                 ObjectPath = objectPath;
                 FsmName = fsmName;
                 Strategy = strategy;
-                AppliedLabel = appliedLabel;
-                ReadyLogKey = readyLogKey;
-                ReadyLogMessage = readyLogMessage;
                 StateName = stateName;
                 ActionIndex = actionIndex;
             }
@@ -95,18 +86,12 @@ namespace MWC_Localization_Core
                 "COMPUTER/SYSTEM/POS/BootSequence",
                 "Use",
                 FsmStrategyType.PosUse,
-                "GAME POS",
-                "POS_USE_READY",
-                "[FsmTextHook] Use FSM is initialized and ready.",
                 null,
                 -1),
             new FsmStrategyTarget(
                 "COMPUTER/SYSTEM/POS/Command",
                 "Typer",
                 FsmStrategyType.PosTyper,
-                "GAME POS",
-                "POS_TYPER_READY",
-                "[FsmTextHook] Typer FSM is initialized and ready.",
                 null,
                 -1)
         };
@@ -117,38 +102,32 @@ namespace MWC_Localization_Core
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/240/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/241/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/302/Texts/Data/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
                 2),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/302/Texts/Data 1/Bottomline 1",
                 "Data",
                 FsmStrategyType.TeletextBuildStringPattern,
-                "GAME Teletext Bottomline",
-                "TTX_DATA_READY",
-                "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
-                3)
+                3),
+            new FsmStrategyTarget(
+                "Systems/TV/TVGraphics/CHAT/Day/Time",
+                "Clock",
+                FsmStrategyType.TeletextBuildStringSimple,
+                "State 3",
+                2)
         };
 
         private static readonly string TeletextEnnusteUpdaterPrefix = "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Ennuste/";
@@ -159,18 +138,12 @@ namespace MWC_Localization_Core
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Nyt",
                 "Logic",
                 FsmStrategyType.TeletextWeatherUpdaterTokens,
-                "GAME Teletext Weather",
-                "TTX_WX_READY",
-                "[FsmTextHook] Teletext weather updater FSM targets are ready.",
                 null,
                 -1),
             new FsmStrategyTarget(
                 "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Ennuste",
                 "Logic",
                 FsmStrategyType.TeletextWeatherUpdaterTokens,
-                "GAME Teletext Weather",
-                "TTX_WX_READY",
-                "[FsmTextHook] Teletext weather updater FSM targets are ready.",
                 null,
                 -1)
         };
@@ -191,9 +164,6 @@ namespace MWC_Localization_Core
                         path,
                         "Button",
                         FsmStrategyType.UnemployPaperButtonVariables,
-                        "GAME UnemployPaper",
-                        "UNEMPLOY_READY",
-                        "[FsmTextHook] UnemployPaper Button FSM targets are ready.",
                         null,
                         -1));
                 }
@@ -201,6 +171,16 @@ namespace MWC_Localization_Core
 
             return targets.ToArray();
         }
+
+        private static readonly FsmStrategyTarget[] GameConlineTargets = new FsmStrategyTarget[]
+        {
+            new FsmStrategyTarget(
+                "COMPUTER/SYSTEM/TELEBBS/CONLINE/CHAT",
+                "Type",
+                FsmStrategyType.ConlineChatStatus,
+                null,
+                -1)
+        };
 
         public void Initialize(Dictionary<string, string> translations, GameObject hostObject, string[] patternFiles)
         {
@@ -233,10 +213,6 @@ namespace MWC_Localization_Core
                 {
                     if (TryApplyMainMenuTranslations())
                     {
-                        appliedTarget = "MainMenu";
-                        string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "Unknown" : appliedTarget;
-                        CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
-                        Cleanup();
                         yield break;
                     }
 
@@ -260,17 +236,11 @@ namespace MWC_Localization_Core
             if (translations == null)
                 return;
 
-            bool anyChanged = false;
-            anyChanged |= TryApplyGamePosFsmTranslations();
-            anyChanged |= TryApplyGameTeletextBottomlineFsmTranslations();
-            anyChanged |= TryApplyGameTeletextWeatherUpdaterFsmTranslations();
-            anyChanged |= TryApplyGameUnemployPaperFsmTranslations();
-
-            if (anyChanged)
-            {
-                string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "GAME" : appliedTarget;
-                CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
-            }
+            TryApplyGamePosFsmTranslations();
+            TryApplyGameTeletextBottomlineFsmTranslations();
+            TryApplyGameTeletextWeatherUpdaterFsmTranslations();
+            TryApplyGameUnemployPaperFsmTranslations();
+            TryApplyGameConlineChatFsmTranslations();
         }
 
         private bool TryApplyMainMenuTranslations()
@@ -312,11 +282,6 @@ namespace MWC_Localization_Core
             bool hasAnyTarget = false;
             ApplyStrategyTargets(GamePosTargets, ref anyChanged, ref hasAnyTarget);
 
-            if (anyChanged)
-            {
-                appliedTarget = "GAME POS";
-            }
-
             return anyChanged || hasAnyTarget;
         }
 
@@ -325,11 +290,6 @@ namespace MWC_Localization_Core
             bool anyChanged = false;
             bool hasAnyTarget = false;
             ApplyStrategyTargets(GameTeletextTargets, ref anyChanged, ref hasAnyTarget);
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME Teletext Bottomline";
-            }
 
             return anyChanged || hasAnyTarget;
         }
@@ -352,14 +312,8 @@ namespace MWC_Localization_Core
                 if (completedEnnusteFsmInstances.Contains(instanceID))
                     continue;
 
-                LogReadyOnce("TTX_WX_READY", "[FsmTextHook] Teletext weather updater FSM targets are ready.");
                 ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
                 completedEnnusteFsmInstances.Add(instanceID);
-            }
-
-            if (anyChanged)
-            {
-                appliedTarget = "GAME Teletext Weather";
             }
 
             return anyChanged || hasAnyTarget;
@@ -372,10 +326,15 @@ namespace MWC_Localization_Core
 
             ApplyStrategyTargets(GameUnemployPaperTargets, ref anyChanged, ref hasAnyTarget);
 
-            if (anyChanged)
-            {
-                appliedTarget = "GAME UnemployPaper";
-            }
+            return anyChanged || hasAnyTarget;
+        }
+
+        private bool TryApplyGameConlineChatFsmTranslations()
+        {
+            bool anyChanged = false;
+            bool hasAnyTarget = false;
+
+            ApplyStrategyTargets(GameConlineTargets, ref anyChanged, ref hasAnyTarget);
 
             return anyChanged || hasAnyTarget;
         }
@@ -399,7 +358,6 @@ namespace MWC_Localization_Core
                 if (!IsFsmReady(fsm))
                     continue;
 
-                LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
                 ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
                 completedStrategyTargets.Add(targetKey);
             }
@@ -447,6 +405,12 @@ namespace MWC_Localization_Core
                     hasAnyTarget |= HasState(fsm, target.StateName);
                     break;
 
+                case FsmStrategyType.TeletextBuildStringSimple:
+                    // For simple translations like KLO->Ás, just translate part[0] without pattern matching
+                    anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, target.StateName, target.ActionIndex, false, 1, 2);
+                    hasAnyTarget |= HasState(fsm, target.StateName);
+                    break;
+
                 case FsmStrategyType.TeletextWeatherUpdaterTokens:
                     ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
                     break;
@@ -455,24 +419,12 @@ namespace MWC_Localization_Core
                     anyChanged |= ApplyUnemployPaperButtonVariableTranslations(fsm);
                     hasAnyTarget = true;
                     break;
+
+                case FsmStrategyType.ConlineChatStatus:
+                    anyChanged |= ApplyConlineChatStatusTranslations(fsm);
+                    hasAnyTarget = true;
+                    break;
             }
-
-            if (anyChanged && !string.IsNullOrEmpty(target.AppliedLabel))
-            {
-                appliedTarget = target.AppliedLabel;
-            }
-        }
-
-        private void LogReadyOnce(string key, string message)
-        {
-            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(message))
-                return;
-
-            if (loggedReadyTargets.Contains(key))
-                return;
-
-            loggedReadyTargets.Add(key);
-            CoreConsole.Print(message);
         }
 
         private bool IsFsmReady(PlayMakerFSM fsm)
@@ -504,6 +456,63 @@ namespace MWC_Localization_Core
             changed |= TranslateFsmStringVariableExact(fsm, "JobYes");
 
             return changed;
+        }
+
+        private bool ApplyConlineChatStatusTranslations(PlayMakerFSM fsm)
+        {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
+            bool changed = false;
+
+            changed |= ApplyConlineNestedTranslation(fsm, "Download", 1);
+            changed |= ApplyConlineNestedTranslation(fsm, "Fail", 0);
+
+            return changed;
+        }
+
+        private bool ApplyConlineNestedTranslation(PlayMakerFSM fsm, string stateName, int actionIndex)
+        {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
+            HutongGames.PlayMaker.FsmState state = null;
+            for (int i = 0; i < fsm.FsmStates.Length; i++)
+            {
+                if (fsm.FsmStates[i] != null && fsm.FsmStates[i].Name == stateName)
+                {
+                    state = fsm.FsmStates[i];
+                    break;
+                }
+            }
+
+            if (state == null || state.Actions == null || actionIndex < 0 || actionIndex >= state.Actions.Length)
+                return false;
+
+            object action = state.Actions[actionIndex];
+            if (action == null)
+                return false;
+
+            var targetProperty = GetCachedField(action.GetType(), "targetProperty")?.GetValue(action);
+            if (targetProperty == null)
+                return false;
+
+            var fsmString = GetCachedField(targetProperty.GetType(), "StringParameter")?
+                .GetValue(targetProperty) as HutongGames.PlayMaker.FsmString;
+
+            if (fsmString == null || string.IsNullOrEmpty(fsmString.Value))
+                return false;
+
+            string original = fsmString.Value;
+            string translated = GetTranslation(original, original);
+
+            if (translated != original)
+            {
+                fsmString.Value = translated;
+                return true;
+            }
+
+            return false;
         }
 
         private bool TranslateFsmStringVariableExact(PlayMakerFSM fsm, string variableName)
@@ -718,17 +727,25 @@ namespace MWC_Localization_Core
                 return false;
 
             bool changed = false;
+            bool patternResolved = false;
+            
             if (allowPatternSplit && isBuildStringFast)
             {
-                changed = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts);
+                patternResolved = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts);
+                changed = patternResolved;
             }
 
-            for (int i = 0; i < parts.Length; i++)
+            // CRITICAL: If pattern matching was applied, DON'T translate individual parts
+            // Otherwise the loop below will corrupt the already-translated parts
+            if (!patternResolved)
             {
-                if (ShouldSkipIndex(i, skipPartIndexes))
-                    continue;
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    if (ShouldSkipIndex(i, skipPartIndexes))
+                        continue;
 
-                changed |= TranslateStringPart(parts[i]);
+                    changed |= TranslateStringPart(parts[i]);
+                }
             }
 
             return changed;
@@ -765,6 +782,13 @@ namespace MWC_Localization_Core
 
             string newPrefix = translatedCombined.Substring(0, middleIndex);
             string newSuffix = translatedCombined.Substring(middleIndex + middleValue.Length);
+            
+            // PROTECTION: Don't reapply translation if already done in previous frame
+            // Check if part0 already matches the translation (avoid redundant updates)
+            string currentPart0 = part0.Value ?? string.Empty;
+            if (currentPart0 == newPrefix && (part2.Value ?? string.Empty) == newSuffix)
+                return false;  // Already translated, skip
+
             bool changed = false;
 
             if (part0.Value != newPrefix)
@@ -829,7 +853,9 @@ namespace MWC_Localization_Core
                 }
             }
 
-            return sb.ToString();
+            string result = sb.ToString();
+            sb.Length = 0;  // NET 3.5 compatible: reset StringBuilder for reuse
+            return result;
         }
 
         private bool ApplyAllStateSetStringValueTranslation(PlayMakerFSM fsm, params string[] skipStateNames)
@@ -1050,6 +1076,12 @@ namespace MWC_Localization_Core
         {
             if (hostObject != null)
                 Object.Destroy(hostObject);
+        }
+
+        private void OnDestroy()
+        {
+            StopCoroutine(ApplyWhenReady());
+            hostObject = null;
         }
     }
 }

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -142,12 +142,16 @@ namespace MWC_Localization_Core
             List<object> keys = new List<object>();
             foreach (object key in hashTable.Keys)
             {
+                if (key == null)
+                    continue;
                 keys.Add(key);
             }
 
             for (int i = 0; i < keys.Count; i++)
             {
                 object key = keys[i];
+                if (key == null)
+                    continue;
                 string original = hashTable[key] as string;
                 if (string.IsNullOrEmpty(original))
                     continue;

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -18,16 +18,6 @@ namespace MWC_Localization_Core
         private HashTableProxyHandler hashTableHandler;
         private SceneTranslationManager sceneManager;
         
-        // Cached references for critical UI (EveryFrame monitoring)
-        private class CriticalUIReference
-        {
-            public string Path;
-            public TextMesh TextMesh;
-            public int RetryCount;
-            public float NextRetryTime;
-            public bool IsRegistered;
-        }
-
         private bool isInitialized = false;
         
         // Throttling timer for array and proxy monitoring

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -8,13 +8,22 @@ namespace MWC_Localization_Core
     /// </summary>
     public static class MLCUtils
     {
+        // LRU cache for FormatUpperKey to reduce allocations in hot path
+        private static Dictionary<string, string> formatKeyCache = new Dictionary<string, string>();
+        private const int FORMAT_KEY_CACHE_MAX = 256;
+
         /// <summary>
         /// Format string for use as translation key (uppercase, no spaces/newlines)
+        /// Cached to reduce allocations in hot path
         /// </summary>
         public static string FormatUpperKey(string original)
         {
             if (string.IsNullOrEmpty(original))
                 return original;
+
+            // Check cache first
+            if (formatKeyCache.TryGetValue(original, out string cached))
+                return cached;
 
             // Single-pass: skip whitespace chars and uppercase in one allocation
             char[] buffer = new char[original.Length];
@@ -30,7 +39,13 @@ namespace MWC_Localization_Core
             if (len == 0)
                 return string.Empty;
 
-            return new string(buffer, 0, len);
+            string result = new string(buffer, 0, len);
+            
+            // Cache result (with limit to prevent unbounded growth)
+            if (formatKeyCache.Count < FORMAT_KEY_CACHE_MAX)
+                formatKeyCache[original] = result;
+
+            return result;
         }
 
         // Cache for GameObject paths to improve performance
@@ -155,6 +170,16 @@ namespace MWC_Localization_Core
             pathCache.Clear();
             gameObjectFindCache.Clear();
             inactiveFsmPathNameCache.Clear();
+            ClearFormatKeyCache();
+        }
+
+        /// <summary>
+        /// Clear FormatUpperKey cache.
+        /// Call this on scene changes to prevent memory bloat.
+        /// </summary>
+        public static void ClearFormatKeyCache()
+        {
+            formatKeyCache.Clear();
         }
     }
 }

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -8,7 +8,9 @@ namespace MWC_Localization_Core
     /// </summary>
     public static class MLCUtils
     {
-        // LRU cache for FormatUpperKey to reduce allocations in hot path
+        // Fixed-size cache for FormatUpperKey to reduce allocations in hot path
+        // Note: This is a bounded cache, not LRU. Once full (256 entries),
+        // new entries are not cached. If LRU behavior is needed, use a different structure.
         private static Dictionary<string, string> formatKeyCache = new Dictionary<string, string>();
         private const int FORMAT_KEY_CACHE_MAX = 256;
 

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -120,6 +120,9 @@ namespace MWC_Localization_Core
             string teletextPath = Path.Combine(ModLoader.GetModAssetsFolder(this), "translate_teletext.txt");
             teletextHandler.LoadTeletextTranslations(teletextPath);
             translator.LoadFsmPatterns(teletextPath); // Load additional FSM patterns
+
+            // Clear format key cache to prevent memory buildup from old scene
+            MLCUtils.ClearFormatKeyCache();
             
             // Initialize array handler with translation dictionaries and translator
             arrayListHandler = new ArrayListProxyHandler(translations, magazineHandler, translator);
@@ -294,6 +297,9 @@ namespace MWC_Localization_Core
 
                 foreach (var pair in config.FontMappings)
                 {
+                    if (string.IsNullOrEmpty(pair.Key) || string.IsNullOrEmpty(pair.Value))
+                        continue;
+
                     Font font = fontBundle.LoadAsset(pair.Value, typeof(Font)) as Font;
                     if (font != null)
                     {
@@ -335,7 +341,7 @@ namespace MWC_Localization_Core
                     if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith("#"))
                         continue;
 
-                    int separatorIndex = FindKeyValueSeparatorIndex(line);
+                    int separatorIndex = TranslationFileParser.FindKeyValueSeparator(line);
                     if (separatorIndex > 0)
                     {
                         string key = line.Substring(0, separatorIndex).Trim().Replace("\\=", "=");
@@ -371,26 +377,7 @@ namespace MWC_Localization_Core
             }
         }
 
-        private static int FindKeyValueSeparatorIndex(string line)
-        {
-            for (int i = 0; i < line.Length; i++)
-            {
-                if (line[i] != '=')
-                    continue;
 
-                int backslashCount = 0;
-                for (int j = i - 1; j >= 0 && line[j] == '\\'; j--)
-                {
-                    backslashCount++;
-                }
-
-                bool isEscaped = (backslashCount % 2) == 1;
-                if (!isEscaped)
-                    return i;
-            }
-
-            return -1;
-        }
 
         void LoadTranslations()
         {
@@ -431,6 +418,12 @@ namespace MWC_Localization_Core
             {
                 InsertTranslationLines(modTranslationPath);
                 translator.LoadFsmPatterns(modTranslationPath);
+            }
+
+            // Log total translations loaded (use ModConsole to always show)
+            if (translations.Count > 0)
+            {
+                ModConsole.Print($"[{Name}] Translations loaded: {translations.Count} entries");
             }
         }
 
@@ -476,7 +469,6 @@ namespace MWC_Localization_Core
                 lateUpdateHandler.ClearCache();
                 // Re-initialize to find critical UI components again
                 lateUpdateHandler.Initialize(
-                    translator, 
                     textMeshMonitor, 
                     teletextHandler, 
                     arrayListHandler, 
@@ -494,7 +486,8 @@ namespace MWC_Localization_Core
             arrayListHandler.Reset();
             hashTableHandler.Reset();
 
-            // Reapply fonts and adjustments to all TextMeshes (after restore)
+            // Reapply translations and fonts only to TextMeshes with actual translations
+            // Pass null to translatedTextMeshes to force retranslation during reload
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
             int reappliedCount = 0;
             foreach (TextMesh tm in allTextMeshes)
@@ -502,8 +495,26 @@ namespace MWC_Localization_Core
                 if (tm != null && !string.IsNullOrEmpty(tm.text))
                 {
                     string path = MLCUtils.GetGameObjectPath(tm.gameObject);
-                    translator.ApplyCustomFont(tm, path);
-                    reappliedCount++;
+                    // Only apply font if there's actually a translation - prevents FSM/game text corruption
+                    if (translator.TranslateAndApplyFont(tm, path, null))
+                    {
+                        reappliedCount++;
+                    }
+                }
+            }
+
+            // Reapply position/size adjustments to ALL TextMeshes (even those without translations)
+            // This ensures config.txt changes are properly applied during reload
+            int adjustmentCount = 0;
+            foreach (TextMesh tm in allTextMeshes)
+            {
+                if (tm != null)
+                {
+                    string path = MLCUtils.GetGameObjectPath(tm.gameObject);
+                    if (config.ApplyTextAdjustment(tm, path))
+                    {
+                        adjustmentCount++;
+                    }
                 }
             }
 
@@ -517,7 +528,7 @@ namespace MWC_Localization_Core
                 InitializeFsmTextHook();
             }
 
-            CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts/adjustments to {reappliedCount} TextMeshes.");
+            CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts to {reappliedCount} TextMeshes, {adjustmentCount} position/size adjustments applied.");
         }
 
         void InitializeFsmTextHook()

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -500,10 +500,17 @@ namespace MWC_Localization_Core
                 if (tm != null && !string.IsNullOrEmpty(tm.text))
                 {
                     string path = MLCUtils.GetGameObjectPath(tm.gameObject);
-                    // Only apply font if there's actually a translation - prevents FSM/game text corruption
-                    if (translator.TranslateAndApplyFont(tm, path, null))
+                    // Try to translate and apply font
+                    bool translated = translator.TranslateAndApplyFont(tm, path, null);
+                    if (translated)
                     {
                         reappliedCount++;
+                    }
+                    // Even if not translated, apply custom font if one exists for this path
+                    // This ensures fonts updated in config.txt are applied to already-localized meshes
+                    else if (!string.IsNullOrEmpty(tm.text))
+                    {
+                        translator.ApplyFontOnly(tm, path);
                     }
                 }
             }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -344,26 +344,27 @@ namespace MWC_Localization_Core
                     int separatorIndex = TranslationFileParser.FindKeyValueSeparator(line);
                     if (separatorIndex > 0)
                     {
-                        string key = line.Substring(0, separatorIndex).Trim().Replace("\\=", "=");
-                        // Preserve intentional leading AND trailing spaces in translation values.
-                        // Spaces are needed for proper formatting in concatenated strings
-                        string value = line.Substring(separatorIndex + 1).Replace("\\=", "=");
-
-                        // Common authoring style is: "key = value".
-                        // In that specific case, drop only the single separator space.
+                        // Use centralized parsing to extract raw key and value
+                        string rawKey = line.Substring(0, separatorIndex).Trim();
+                        string rawValue = line.Substring(separatorIndex + 1);
+                        
+                        // Apply unescape and common spacing rules (drop single separator space)
+                        string unescapedKey = rawKey.Replace("\\=", "=");
+                        string unescapedValue = TranslationFileParser.UnescapeValue(rawValue);
+                        
+                        // Drop the single space after "=" only if authored as "key = value"
                         if (line.Length > separatorIndex + 1 && line[separatorIndex + 1] == ' ')
                         {
                             bool hasSecondSpace = (line.Length > separatorIndex + 2 && line[separatorIndex + 2] == ' ');
-                            if (!hasSecondSpace && value.Length > 0 && value[0] == ' ')
-                                value = value.Substring(1);
+                            if (!hasSecondSpace && unescapedValue.Length > 0 && unescapedValue[0] == ' ')
+                                unescapedValue = unescapedValue.Substring(1);
                         }
 
-                        string normalizedKey = MLCUtils.FormatUpperKey(key);
-                        string processedValue = value.Replace("\\n", "\n");
+                        string normalizedKey = MLCUtils.FormatUpperKey(unescapedKey);
 
                         if (!string.IsNullOrEmpty(normalizedKey))
                         {
-                            translations[normalizedKey] = processedValue;
+                            translations[normalizedKey] = unescapedValue;
                         }
                     }
                 }
@@ -486,6 +487,10 @@ namespace MWC_Localization_Core
             arrayListHandler.Reset();
             hashTableHandler.Reset();
 
+            // Reload custom font mappings from config before reapplying fonts
+            customFonts.Clear();
+            LoadCustomFonts();
+            
             // Reapply translations and fonts only to TextMeshes with actual translations
             // Pass null to translatedTextMeshes to force retranslation during reload
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -224,6 +224,14 @@ namespace MWC_Localization_Core
                     lateUpdateHandlerObject = null;
                     lateUpdateHandler = null;
                 }
+                
+                // Destroy FSM hook when leaving both MainMenu and GAME (stops coroutine and clears reflection cache)
+                if (currentScene != "MainMenu" && currentScene != "GAME" && fsmTextHookObject != null)
+                {
+                    Object.Destroy(fsmTextHookObject);
+                    fsmTextHookObject = null;
+                }
+                
                 CoreConsole.Print($"[{Name}] Scene changed to '{currentScene}' - cleared caches");
             }
 
@@ -374,7 +382,6 @@ namespace MWC_Localization_Core
                 }
 
                 hasLoadedTranslations = true;
-                CoreConsole.Print($"[{Name}] Loaded {translations.Count} translations from {Path.GetFileName(translationPath)}");
             }
             catch (System.Exception ex)
             {
@@ -425,11 +432,7 @@ namespace MWC_Localization_Core
                 translator.LoadFsmPatterns(modTranslationPath);
             }
 
-            // Log total translations loaded (use ModConsole to always show)
-            if (translations.Count > 0)
-            {
-                ModConsole.Print($"[{Name}] Translations loaded: {translations.Count} entries");
-            }
+
         }
 
         void ReloadTranslations()
@@ -452,14 +455,17 @@ namespace MWC_Localization_Core
 
             // Reload from file
             LoadTranslations();
+            int totalTranslationsReloaded = translations.Count;
 
             // Reload magazine translations
             string magazinePath = Path.Combine(ModLoader.GetModAssetsFolder(this), "translate_magazine.txt");
             magazineHandler.LoadMagazineTranslations(magazinePath);
+            totalTranslationsReloaded += magazineHandler.GetTranslationCount();
             
             // Reload teletext translations
             string teletextPath = Path.Combine(ModLoader.GetModAssetsFolder(this), "translate_teletext.txt");
             teletextHandler.LoadTeletextTranslations(teletextPath);
+            totalTranslationsReloaded += teletextHandler.GetTranslationCount();
             
             // Reload FSM patterns from main file first
             string mainTranslatePath = Path.Combine(ModLoader.GetModAssetsFolder(this), "translate.txt");
@@ -564,7 +570,7 @@ namespace MWC_Localization_Core
                 InitializeFsmTextHook();
             }
 
-            CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts to {reappliedCount} TextMeshes, {adjustmentCount} position/size adjustments applied.");
+            CoreConsole.Print($"[{Name}] [F8] Reloaded {totalTranslationsReloaded} translations. Reapplied fonts to {reappliedCount} TextMeshes, {adjustmentCount} position/size adjustments applied.");
         }
 
         /// <summary>

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -486,6 +486,10 @@ namespace MWC_Localization_Core
             sceneManager.ResetAll();
             textMeshMonitor.Clear();
             
+            // CRITICAL: Clear originalMeshText to prevent stale originals from reload
+            // Otherwise RegisterOriginalMeshText will overwrite with already-translated text
+            originalMeshText.Clear();
+            
             // Reset teletext handler
             teletextHandler.Reset();
             arrayListHandler.Reset();
@@ -511,13 +515,19 @@ namespace MWC_Localization_Core
                     if (originalMeshText.TryGetValue(path, out string originalText))
                     {
                         // Found original - use it for retranslation
+                        // CRITICAL: Reset tm.text to originalText BEFORE calling TranslateAndApplyFont
+                        // Otherwise translator.ApplyTranslation() looks up the already-translated text instead
+                        tm.text = originalText;
+                        
                         // Reuse tempMeshSet to avoid per-iteration allocation
+                        // CRITICAL: Do NOT pre-add tm to tempMeshSet - that causes TranslateAndApplyFont to skip processing
                         tempMeshSet.Clear();
-                        tempMeshSet.Add(tm);
                         bool translated = translator.TranslateAndApplyFont(tm, path, tempMeshSet);
                         if (translated)
                         {
                             reappliedCount++;
+                            // Add to set AFTER successful translation
+                            tempMeshSet.Add(tm);
                         }
                         // Even if not translated, apply custom font if one exists for this path
                         else if (!string.IsNullOrEmpty(tm.text))
@@ -560,11 +570,13 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Register original text for a mesh path to enable re-translation on reload
         /// Called by UnifiedTextMeshMonitor before translating a new mesh
+        /// CRITICAL: Allows updating existing keys to handle mesh recreation/refresh scenarios
         /// </summary>
         public void RegisterOriginalMeshText(string meshPath, string originalText)
         {
-            if (!string.IsNullOrEmpty(meshPath) && !originalMeshText.ContainsKey(meshPath))
+            if (!string.IsNullOrEmpty(meshPath))
             {
+                // Allow updating existing keys - meshes may be recreated or need refresh
                 originalMeshText[meshPath] = originalText;
             }
         }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -499,19 +499,22 @@ namespace MWC_Localization_Core
             // Use stored original text to enable re-translation of already-localized meshes
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
             int reappliedCount = 0;
+            HashSet<TextMesh> tempMeshSet = new HashSet<TextMesh>();  // Reusable set for tracking
+            
             foreach (TextMesh tm in allTextMeshes)
             {
                 if (tm != null && !string.IsNullOrEmpty(tm.text))
                 {
                     string path = MLCUtils.GetGameObjectPath(tm.gameObject);
                     
-                    // Lookup original text for this mesh to enable re-translation
-                    string originalText = null;
-                    if (originalMeshText.TryGetValue(path, out originalText))
+                    // Only process meshes that were previously translated (have original stored)
+                    if (originalMeshText.TryGetValue(path, out string originalText))
                     {
                         // Found original - use it for retranslation
-                        // Pass as a HashSet containing just this mesh for tracking
-                        bool translated = translator.TranslateAndApplyFont(tm, path, new HashSet<TextMesh> { tm });
+                        // Reuse tempMeshSet to avoid per-iteration allocation
+                        tempMeshSet.Clear();
+                        tempMeshSet.Add(tm);
+                        bool translated = translator.TranslateAndApplyFont(tm, path, tempMeshSet);
                         if (translated)
                         {
                             reappliedCount++;
@@ -522,11 +525,7 @@ namespace MWC_Localization_Core
                             translator.ApplyFontOnly(tm, path);
                         }
                     }
-                    else
-                    {
-                        // No original stored - just apply font for already-localized meshes
-                        translator.ApplyFontOnly(tm, path);
-                    }
+                    // If no original stored: mesh was never translated, so skip it (don't modify fonts)
                 }
             }
 

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -48,6 +48,10 @@ namespace MWC_Localization_Core
         // Font management
         private static AssetBundle fontBundle;  // Static to persist across MSCLoader instance recreation
         private Dictionary<string, Font> customFonts = new Dictionary<string, Font>();
+        
+        // Store original text for each TextMesh to enable re-translation on config reload
+        // Key: GameObject path, Value: original text before translation
+        private Dictionary<string, string> originalMeshText = new Dictionary<string, string>();
 
         // Localization configuration
         private LocalizationConfig config;
@@ -130,8 +134,8 @@ namespace MWC_Localization_Core
             hashTableHandler = new HashTableProxyHandler(magazineHandler);
             hashTableHandler.InitializeTargetPaths();
             
-            // Initialize unified text mesh monitor
-            textMeshMonitor = new UnifiedTextMeshMonitor(translator);
+            // Initialize unified text mesh monitor with reference to plugin for registering original text
+            textMeshMonitor = new UnifiedTextMeshMonitor(translator, this);
 
             // Translate main menu
             CoreConsole.Print($"[{Name}] Translating Main Menu...");
@@ -492,7 +496,7 @@ namespace MWC_Localization_Core
             LoadCustomFonts();
             
             // Reapply translations and fonts only to TextMeshes with actual translations
-            // Pass null to translatedTextMeshes to force retranslation during reload
+            // Use stored original text to enable re-translation of already-localized meshes
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
             int reappliedCount = 0;
             foreach (TextMesh tm in allTextMeshes)
@@ -500,16 +504,27 @@ namespace MWC_Localization_Core
                 if (tm != null && !string.IsNullOrEmpty(tm.text))
                 {
                     string path = MLCUtils.GetGameObjectPath(tm.gameObject);
-                    // Try to translate and apply font
-                    bool translated = translator.TranslateAndApplyFont(tm, path, null);
-                    if (translated)
+                    
+                    // Lookup original text for this mesh to enable re-translation
+                    string originalText = null;
+                    if (originalMeshText.TryGetValue(path, out originalText))
                     {
-                        reappliedCount++;
+                        // Found original - use it for retranslation
+                        // Pass as a HashSet containing just this mesh for tracking
+                        bool translated = translator.TranslateAndApplyFont(tm, path, new HashSet<TextMesh> { tm });
+                        if (translated)
+                        {
+                            reappliedCount++;
+                        }
+                        // Even if not translated, apply custom font if one exists for this path
+                        else if (!string.IsNullOrEmpty(tm.text))
+                        {
+                            translator.ApplyFontOnly(tm, path);
+                        }
                     }
-                    // Even if not translated, apply custom font if one exists for this path
-                    // This ensures fonts updated in config.txt are applied to already-localized meshes
-                    else if (!string.IsNullOrEmpty(tm.text))
+                    else
                     {
+                        // No original stored - just apply font for already-localized meshes
                         translator.ApplyFontOnly(tm, path);
                     }
                 }
@@ -541,6 +556,18 @@ namespace MWC_Localization_Core
             }
 
             CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts to {reappliedCount} TextMeshes, {adjustmentCount} position/size adjustments applied.");
+        }
+
+        /// <summary>
+        /// Register original text for a mesh path to enable re-translation on reload
+        /// Called by UnifiedTextMeshMonitor before translating a new mesh
+        /// </summary>
+        public void RegisterOriginalMeshText(string meshPath, string originalText)
+        {
+            if (!string.IsNullOrEmpty(meshPath) && !originalMeshText.ContainsKey(meshPath))
+            {
+                originalMeshText[meshPath] = originalText;
+            }
         }
 
         void InitializeFsmTextHook()

--- a/MWC_Localization_Core.csproj
+++ b/MWC_Localization_Core.csproj
@@ -83,6 +83,7 @@
     <Compile Include="MLCUtils.cs" />
     <Compile Include="TeletextHandler.cs" />
     <Compile Include="TextMeshTranslator.cs" />
+    <Compile Include="TranslationFileParser.cs" />
     <Compile Include="TranslationPattern.cs" />
     <Compile Include="UnifiedTextMeshMonitor.cs" />
   </ItemGroup>

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -29,6 +29,14 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Get total count of loaded magazine translations
+        /// </summary>
+        public int GetTranslationCount()
+        {
+            return magazineTranslations.Count;
+        }
+
+        /// <summary>
         /// Check if path is a magazine text element
         /// </summary>
         public bool IsMagazineText(string path)

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -21,49 +21,11 @@ namespace MWC_Localization_Core
         /// </summary>
         public void LoadMagazineTranslations(string translationPath)
         {
-            if (!File.Exists(translationPath))
-            {
-                CoreConsole.Warning($"[MagazineTextHandler] Magazine translation file not found: {translationPath}");
-                return;
-            }
-
-            try
-            {
-                string[] lines = File.ReadAllLines(translationPath, Encoding.UTF8);
-                magazineTranslations.Clear();
-
-                foreach (string line in lines)
-                {
-                    // Skip empty lines and comments
-                    if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(line.Trim()) || line.TrimStart().StartsWith("#"))
-                        continue;
-
-                    // Parse KEY=VALUE format
-                    int equalsIndex = line.IndexOf('=');
-                    if (equalsIndex > 0)
-                    {
-                        string key = line.Substring(0, equalsIndex).Trim();
-                        string value = line.Substring(equalsIndex + 1).Trim();
-
-                        // Normalize key (remove spaces, convert to uppercase)
-                        key = MLCUtils.FormatUpperKey(key);
-
-                        // Handle escaped newlines in value
-                        value = value.Replace("\\n", "\n");
-
-                        if (!magazineTranslations.ContainsKey(key))
-                        {
-                            magazineTranslations[key] = value;
-                        }
-                    }
-                }
-
-                CoreConsole.Print($"[MagazineTextHandler] Loaded {magazineTranslations.Count} magazine translations");
-            }
-            catch (System.Exception ex)
-            {
-                CoreConsole.Error($"[MagazineTextHandler] Failed to load magazine translations: {ex.Message}");
-            }
+            // Use shared parser from TranslationFileParser
+            Dictionary<string, string> loadedTranslations = TranslationFileParser.ParseKeyValueFile(translationPath, normalizeKeys: true);
+            
+            magazineTranslations = loadedTranslations;
+            CoreConsole.Print($"[MagazineTextHandler] Loaded {magazineTranslations.Count} magazine translations");
         }
 
         /// <summary>

--- a/PatternMatcher.cs
+++ b/PatternMatcher.cs
@@ -117,7 +117,7 @@ namespace MWC_Localization_Core
                     }
                 }
 
-                CoreConsole.Print($"[PatternMatcher] Loaded {loadedCount} patterns from file");
+                CoreConsole.Print($"[PatternMatcher] Loaded {loadedCount} patterns from {Path.GetFileName(filePath)}");
             }
             catch (System.Exception ex)
             {
@@ -129,7 +129,7 @@ namespace MWC_Localization_Core
         {
             pattern = null;
             
-            int equalsIndex = FindUnescapedEquals(line);
+            int equalsIndex = TranslationFileParser.FindKeyValueSeparator(line);
             if (equalsIndex <= 0)
                 return false;
 
@@ -137,8 +137,8 @@ namespace MWC_Localization_Core
             string translation = line.Substring(equalsIndex + 1).Trim();
 
             // Unescape special characters
-            original = UnescapeString(original);
-            translation = UnescapeString(translation);
+            original = TranslationFileParser.UnescapeString(original);
+            translation = TranslationFileParser.UnescapeString(translation);
 
             if (string.IsNullOrEmpty(original) || string.IsNullOrEmpty(translation))
                 return false;
@@ -205,15 +205,6 @@ namespace MWC_Localization_Core
         public void AddPattern(TranslationPattern pattern)
         {
             AddPatternInternal(pattern, false);
-        }
-
-        /// <summary>
-        /// Clear all patterns
-        /// </summary>
-        public void ClearPatterns()
-        {
-            patterns.Clear();
-            patternSignatures.Clear();
         }
 
         private bool AddPatternInternal(TranslationPattern pattern, bool appendToEnd)
@@ -329,27 +320,6 @@ namespace MWC_Localization_Core
         }
 
         // Utility methods from TeletextHandler
-        private int FindUnescapedEquals(string line)
-        {
-            for (int i = 0; i < line.Length; i++)
-            {
-                if (line[i] == '=')
-                {
-                    // Check if escaped
-                    if (i > 0 && line[i - 1] == '\\')
-                        continue;
-                    return i;
-                }
-            }
-            return -1;
-        }
 
-        private string UnescapeString(string str)
-        {
-            if (string.IsNullOrEmpty(str))
-                return str;
-            
-            return str.Replace("\\=", "=").Replace("\\n", "\n");
-        }
     }
 }

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -63,6 +63,9 @@ namespace MWC_Localization_Core
         /// </summary>
         public bool UpdateScene(string newScene)
         {
+            if (string.IsNullOrEmpty(newScene))
+                return false;
+
             if (currentScene != newScene)
             {
                 previousScene = currentScene;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -210,11 +210,9 @@ namespace MWC_Localization_Core
                     // Try exact key match first
                     if (translations.TryGetValue(normalizedOriginal, out string translation))
                     {
-                        if (!string.IsNullOrEmpty(translation))
-                        {
-                            arrayList[i] = translation;
-                            translatedCount++;
-                        }
+                        // Apply translation even if empty string - user may have intentionally translated to empty
+                        arrayList[i] = translation;
+                        translatedCount++;
                     }
                     // Fallback: Use index-based translation if available
                     else if (hasIndexFallback && nonEmptySourceIndex < indexBasedTranslations[categoryName].Count)

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -52,200 +52,32 @@ namespace MWC_Localization_Core
         /// </summary>
         public void LoadTeletextTranslations(string filePath)
         {
-            if (!System.IO.File.Exists(filePath))
-            {
-                CoreConsole.Warning($"Teletext translation file not found: {filePath}");
-                return;
-            }
+            // Use shared parser from TranslationFileParser
+            TranslationFileParser.ParseCategoryBasedFile(
+                filePath,
+                out Dictionary<string, Dictionary<string, string>> loadedCategoryTranslations,
+                out Dictionary<string, List<string>> loadedIndexBasedTranslations);
 
-            try
-            {
-                categoryTranslations.Clear();
-                indexBasedTranslations.Clear();
-                
-                string currentCategory = null;
-                Dictionary<string, string> currentDict = null;
-                List<string> currentIndexList = null;
-                int loadedCount = 0;
-
-                string[] lines = System.IO.File.ReadAllLines(filePath, System.Text.Encoding.UTF8);
-                
-                List<string> keyLines = new List<string>();
-                List<string> valueLines = new List<string>();
-                bool readingValue = false;
-                
-                for (int i = 0; i < lines.Length; i++)
-                {
-                    string line = lines[i];
-                    string trimmed = line.Trim();
-
-                    // Skip comments
-                    if (trimmed.StartsWith("#"))
-                        continue;
-
-                    // Check for category header [categoryName]
-                    if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
-                    {
-                        // Save previous entry if exists
-                        if (keyLines.Count > 0 && currentDict != null)
-                        {
-                            SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
-                        }
-                        
-                        keyLines.Clear();
-                        valueLines.Clear();
-                        readingValue = false;
-                        
-                        currentCategory = trimmed.Substring(1, trimmed.Length - 2);
-                        
-                        if (!categoryTranslations.ContainsKey(currentCategory))
-                            categoryTranslations[currentCategory] = new Dictionary<string, string>();
-                        
-                        if (!indexBasedTranslations.ContainsKey(currentCategory))
-                            indexBasedTranslations[currentCategory] = new List<string>();
-                        
-                        currentDict = categoryTranslations[currentCategory];
-                        currentIndexList = indexBasedTranslations[currentCategory];
-                        continue;
-                    }
-
-                    // Skip empty lines outside of key/value context
-                    if (string.IsNullOrEmpty(trimmed))
-                    {
-                        // Empty line between entries - save current entry
-                        if (keyLines.Count > 0 && currentDict != null)
-                        {
-                            SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
-                            keyLines.Clear();
-                            valueLines.Clear();
-                            readingValue = false;
-                        }
-                        continue;
-                    }
-
-                    // Check if this line is just "=" (separator)
-                    if (trimmed == "=")
-                    {
-                        readingValue = true;
-                        continue;
-                    }
-
-                    // Check if line contains unescaped "=" (single-line format)
-                    int equalsIndex = FindUnescapedEquals(line);
-                    if (equalsIndex > 0 && !readingValue)
-                    {
-                        // Single-line format: KEY = VALUE
-                        string key = line.Substring(0, equalsIndex).Trim();
-                        string value = line.Substring(equalsIndex + 1).Trim();
-                        
-                        // Unescape special characters
-                        key = UnescapeString(key);
-                        value = UnescapeString(value);
-
-                        if (!string.IsNullOrEmpty(key) && currentDict != null)
-                        {
-                            currentDict[key] = value;
-                            currentIndexList.Add(value); // Add to index list in order
-                            loadedCount++;
-                        }
-                        continue;
-                    }
-
-                    // Accumulate lines for multi-line key or value
-                    if (currentDict != null)
-                    {
-                        if (readingValue)
-                        {
-                            valueLines.Add(line);
-                        }
-                        else
-                        {
-                            keyLines.Add(line);
-                        }
-                    }
-                }
-
-                // Save last entry if exists
-                if (keyLines.Count > 0 && currentDict != null)
-                {
-                    SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
-                }
-
-                // Create alias: ChatMessages.Messages uses ChatMessages.All translations
-                Dictionary<string, string> chatAllDict;
-                if (categoryTranslations.TryGetValue("ChatMessages.All", out chatAllDict))
-                {
-                    categoryTranslations["ChatMessages.Messages"] = chatAllDict;
-                }
-
-                CoreConsole.Print($"[TeletextHandler] Loaded {loadedCount} teletext translations across {categoryTranslations.Count} categories");
-            }
-            catch (System.Exception ex)
-            {
-                CoreConsole.Error($"[TeletextHandler] Error loading teletext translations: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Find the index of the first unescaped '=' character
-        /// Returns -1 if no unescaped '=' is found
-        /// </summary>
-        private int FindUnescapedEquals(string line)
-        {
-            for (int i = 0; i < line.Length; i++)
-            {
-                if (line[i] == '=')
-                {
-                    // Check if it's escaped (preceded by backslash)
-                    if (i > 0 && line[i - 1] == '\\')
-                    {
-                        // This equals is escaped, skip it
-                        continue;
-                    }
-                    return i;
-                }
-            }
-            return -1;
-        }
-        
-        /// <summary>
-        /// Unescape special characters: \= -> =, \n -> newline
-        /// </summary>
-        private string UnescapeString(string input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return input;
+            categoryTranslations = loadedCategoryTranslations;
+            indexBasedTranslations = loadedIndexBasedTranslations;
             
-            // Replace escape sequences
-            return input.Replace("\\=", "=").Replace("\\n", "\n");
-        }
-        
-        /// <summary>
-        /// Helper method to save a multi-line entry
-        /// </summary>
-        private void SaveEntry(Dictionary<string, string> dict, List<string> indexList, List<string> keyLines, List<string> valueLines, ref int count)
-        {
-            if (keyLines.Count == 0) return;
-
-            // Join lines with newlines, preserving original formatting
-            string key = string.Join("\n", keyLines.ToArray());
-            string value = valueLines.Count > 0 ? string.Join("\n", valueLines.ToArray()) : "";
-
-            // Trim trailing/leading empty lines but preserve internal structure
-            key = key.Trim();
-            value = value.Trim();
-            
-            // Unescape special characters in both key and value
-            key = UnescapeString(key);
-            value = UnescapeString(value);
-
-            if (!string.IsNullOrEmpty(key))
+            // Create alias: ChatMessages.Messages uses ChatMessages.All translations
+            if (categoryTranslations.TryGetValue("ChatMessages.All", out Dictionary<string, string> chatAllDict))
             {
-                dict[key] = value;
-                indexList.Add(value); // Add to index list in order
-                count++;
+                categoryTranslations["ChatMessages.Messages"] = chatAllDict;
             }
+
+            // Count total loaded translations
+            int loadedCount = 0;
+            foreach (var category in categoryTranslations.Values)
+            {
+                loadedCount += category.Count;
+            }
+
+            CoreConsole.Print($"[TeletextHandler] Loaded {loadedCount} teletext translations across {categoryTranslations.Count} categories");
         }
+
+
 
         /// <summary>
         /// Monitor and translate teletext arrays
@@ -370,8 +202,11 @@ namespace MWC_Localization_Core
                     // Try exact key match first
                     if (translations.TryGetValue(normalizedOriginal, out string translation))
                     {
-                        arrayList[i] = translation;
-                        translatedCount++;
+                        if (!string.IsNullOrEmpty(translation))
+                        {
+                            arrayList[i] = translation;
+                            translatedCount++;
+                        }
                     }
                     // Fallback: Use index-based translation if available
                     else if (hasIndexFallback && nonEmptySourceIndex < indexBasedTranslations[categoryName].Count)

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -61,10 +61,18 @@ namespace MWC_Localization_Core
             categoryTranslations = loadedCategoryTranslations;
             indexBasedTranslations = loadedIndexBasedTranslations;
             
-            // Create alias: ChatMessages.Messages uses ChatMessages.All translations
+            // Create alias: ChatMessages.Messages uses ChatMessages.All translations (both category and index-based)
             if (categoryTranslations.TryGetValue("ChatMessages.All", out Dictionary<string, string> chatAllDict))
             {
                 categoryTranslations["ChatMessages.Messages"] = chatAllDict;
+            }
+            
+            // Also create alias for index-based translations (preserve exact array order)
+            if (indexBasedTranslations.TryGetValue("ChatMessages.All", out List<string> chatAllIndexList))
+            {
+                // Copy the list (not reference) to preserve independence
+                List<string> copiedList = new List<string>(chatAllIndexList);
+                indexBasedTranslations["ChatMessages.Messages"] = copiedList;
             }
 
             // Count total loaded translations

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -30,6 +30,9 @@ namespace MWC_Localization_Core
         // Track which arrays have been translated already
         private HashSet<string> translatedArrays = new HashSet<string>();
         
+        // Store count of loaded translations for reporting
+        private int lastLoadedTranslationCount = 0;
+        
         // GameObject path to category mapping
         private Dictionary<string, string> pathPrefixes = new Dictionary<string, string>
         {
@@ -76,13 +79,21 @@ namespace MWC_Localization_Core
             }
 
             // Count total loaded translations
-            int loadedCount = 0;
+            lastLoadedTranslationCount = 0;
             foreach (var category in categoryTranslations.Values)
             {
-                loadedCount += category.Count;
+                lastLoadedTranslationCount += category.Count;
             }
 
-            CoreConsole.Print($"[TeletextHandler] Loaded {loadedCount} teletext translations across {categoryTranslations.Count} categories");
+            CoreConsole.Print($"[TeletextHandler] Loaded {lastLoadedTranslationCount} teletext translations across {categoryTranslations.Count} categories");
+        }
+
+        /// <summary>
+        /// Get total count of loaded teletext translations
+        /// </summary>
+        public int GetTranslationCount()
+        {
+            return lastLoadedTranslationCount;
         }
 
 

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -251,13 +251,21 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Get custom font for the given original font name
+        /// Get custom font for the given original font name (idempotent)
         /// </summary>
         Font GetCustomFont(string originalFontName)
         {
             // Try direct match by mapping key
             if (customFonts.TryGetValue(originalFontName, out Font font))
                 return font;
+
+            // Fallback: scan all entries to find one whose mapped font has this name
+            // This handles the case where textMesh.font.name is already the localized name
+            foreach (var kvp in customFonts)
+            {
+                if (kvp.Value != null && kvp.Value.name == originalFontName)
+                    return kvp.Value;
+            }
 
             return null;
         }

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -17,7 +17,6 @@ namespace MWC_Localization_Core
         private LocalizationConfig config;
         private Dictionary<int, string> appliedFontCache = new Dictionary<int, string>();
         private Dictionary<int, Texture> appliedRuntimeTextureCache = new Dictionary<int, Texture>();
-        private Dictionary<string, Font> fontNameToFont;  // Reverse lookup: font.name -> Font
 
         private static readonly string[] ExcludedPath = new string[]
         {
@@ -42,20 +41,6 @@ namespace MWC_Localization_Core
 
             // Initialize unified pattern matcher
             this.patternMatcher = new PatternMatcher(translations);
-
-            // Build reverse font lookup for O(1) access by font.name
-            RebuildFontNameLookup();
-        }
-
-        private void RebuildFontNameLookup()
-        {
-            fontNameToFont = new Dictionary<string, Font>();
-            if (customFonts == null) return;
-            foreach (var kvp in customFonts)
-            {
-                if (kvp.Value != null && !fontNameToFont.ContainsKey(kvp.Value.name))
-                    fontNameToFont[kvp.Value.name] = kvp.Value;
-            }
         }
 
         /// <summary>
@@ -270,13 +255,9 @@ namespace MWC_Localization_Core
         /// </summary>
         Font GetCustomFont(string originalFontName)
         {
-            // First try direct match by mapping key
+            // Try direct match by mapping key
             if (customFonts.TryGetValue(originalFontName, out Font font))
                 return font;
-
-            // Reverse lookup: font already has a custom font name (e.g. after reload)
-            if (fontNameToFont != null && fontNameToFont.TryGetValue(originalFontName, out Font reverseFont))
-                return reverseFont;
 
             return null;
         }
@@ -318,6 +299,7 @@ namespace MWC_Localization_Core
         {
             appliedFontCache.Clear();
             appliedRuntimeTextureCache.Clear();
+            MLCUtils.ClearFormatKeyCache();
         }
     }
 }

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -74,10 +74,13 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Find the index of the first unescaped '=' character
         /// Public utility for other components that need to parse KEY=VALUE format
-        /// Returns -1 if no unescaped '=' is found
+        /// Returns -1 if no unescaped '=' is found or if line is null/empty
         /// </summary>
         public static int FindKeyValueSeparator(string line)
         {
+            if (string.IsNullOrEmpty(line))
+                return -1;
+                
             return FindKeyValueSeparatorIndex(line);
         }
 

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace MWC_Localization_Core
+{
+    /// <summary>
+    /// Unified translation file parser - eliminates code duplication
+    /// Supports both simple KEY=VALUE files and category-based INI-style files
+    /// </summary>
+    public static class TranslationFileParser
+    {
+        /// <summary>
+        /// Parse KEY=VALUE translation file (simple format)
+        /// Supports escaped equals (\=) and preserves intentional spacing
+        /// </summary>
+        public static Dictionary<string, string> ParseKeyValueFile(string filePath, bool normalizeKeys = true)
+        {
+            var result = new Dictionary<string, string>();
+
+            if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+                return result;
+
+            try
+            {
+                string[] lines = File.ReadAllLines(filePath, Encoding.UTF8);
+
+                foreach (string line in lines)
+                {
+                    if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith("#"))
+                        continue;
+
+                    // Find the first UNESCAPED '=' character
+                    int separatorIndex = FindKeyValueSeparatorIndex(line);
+                    if (separatorIndex <= 0)
+                        continue;
+
+                    // Extract key and value, unescape \= -> =
+                    string key = line.Substring(0, separatorIndex).Trim().Replace("\\=", "=");
+                    // Preserve intentional leading AND trailing spaces in translation values.
+                    // Spaces are needed for proper formatting in concatenated strings
+                    string value = line.Substring(separatorIndex + 1).Replace("\\=", "=");
+
+                    // Common authoring style is: "key = value".
+                    // In that specific case, drop only the single separator space.
+                    if (line.Length > separatorIndex + 1 && line[separatorIndex + 1] == ' ')
+                    {
+                        bool hasSecondSpace = (line.Length > separatorIndex + 2 && line[separatorIndex + 2] == ' ');
+                        if (!hasSecondSpace && value.Length > 0 && value[0] == ' ')
+                            value = value.Substring(1);
+                    }
+
+                    if (string.IsNullOrEmpty(key))
+                        continue;
+
+                    if (normalizeKeys)
+                        key = MLCUtils.FormatUpperKey(key);
+
+                    string processedValue = value.Replace("\\n", "\n");
+
+                    if (!result.ContainsKey(key))
+                        result[key] = processedValue;
+                }
+            }
+            catch (Exception ex)
+            {
+                CoreConsole.Error($"[TranslationFileParser] Error parsing KEY=VALUE file: {ex.Message}");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Find the index of the first unescaped '=' character
+        /// Public utility for other components that need to parse KEY=VALUE format
+        /// Returns -1 if no unescaped '=' is found
+        /// </summary>
+        public static int FindKeyValueSeparator(string line)
+        {
+            return FindKeyValueSeparatorIndex(line);
+        }
+
+        /// <summary>
+        /// Unescape special characters: \= -> =, \n -> newline
+        /// Public utility for other components
+        /// </summary>
+        public static string UnescapeValue(string input)
+        {
+            return UnescapeString(input);
+        }
+
+        /// <summary>
+        /// Find the index of the first unescaped '=' character
+        /// Returns -1 if no unescaped '=' is found
+        /// </summary>
+        private static int FindKeyValueSeparatorIndex(string line)
+        {
+            for (int i = 0; i < line.Length; i++)
+            {
+                if (line[i] != '=')
+                    continue;
+
+                int backslashCount = 0;
+                for (int j = i - 1; j >= 0 && line[j] == '\\'; j--)
+                {
+                    backslashCount++;
+                }
+
+                bool isEscaped = (backslashCount % 2) == 1;
+                if (!isEscaped)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Parse INI-style category-based file with [categoryName] sections
+        /// Used for teletext translations with category-based + index-based lookups
+        /// Returns both dictionary-based and list-based (index-based) translations
+        /// </summary>
+        public static void ParseCategoryBasedFile(
+            string filePath,
+            out Dictionary<string, Dictionary<string, string>> categoryTranslations,
+            out Dictionary<string, List<string>> indexBasedTranslations)
+        {
+            categoryTranslations = new Dictionary<string, Dictionary<string, string>>();
+            indexBasedTranslations = new Dictionary<string, List<string>>();
+
+            if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+                return;
+
+            try
+            {
+                string currentCategory = null;
+                Dictionary<string, string> currentDict = null;
+                List<string> currentIndexList = null;
+                int loadedCount = 0;
+
+                string[] lines = File.ReadAllLines(filePath, Encoding.UTF8);
+
+                List<string> keyLines = new List<string>();
+                List<string> valueLines = new List<string>();
+                bool readingValue = false;
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string line = lines[i];
+                    string trimmed = line.Trim();
+
+                    // Skip comments
+                    if (trimmed.StartsWith("#"))
+                        continue;
+
+                    // Check for category header [categoryName]
+                    if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
+                    {
+                        // Save previous entry if exists
+                        if (keyLines.Count > 0 && currentDict != null)
+                        {
+                            SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
+                        }
+
+                        keyLines.Clear();
+                        valueLines.Clear();
+                        readingValue = false;
+
+                        currentCategory = trimmed.Substring(1, trimmed.Length - 2);
+
+                        if (!categoryTranslations.ContainsKey(currentCategory))
+                            categoryTranslations[currentCategory] = new Dictionary<string, string>();
+
+                        if (!indexBasedTranslations.ContainsKey(currentCategory))
+                            indexBasedTranslations[currentCategory] = new List<string>();
+
+                        currentDict = categoryTranslations[currentCategory];
+                        currentIndexList = indexBasedTranslations[currentCategory];
+                        continue;
+                    }
+
+                    // Skip empty lines outside of key/value context
+                    if (string.IsNullOrEmpty(trimmed))
+                    {
+                        // Empty line between entries - save current entry
+                        if (keyLines.Count > 0 && currentDict != null)
+                        {
+                            SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
+                            keyLines.Clear();
+                            valueLines.Clear();
+                            readingValue = false;
+                        }
+                        continue;
+                    }
+
+                    // Check if this line is just "=" (separator)
+                    if (trimmed == "=")
+                    {
+                        readingValue = true;
+                        continue;
+                    }
+
+                    // Check if line contains unescaped "=" (single-line format)
+                    int equalsIndex = FindKeyValueSeparatorIndex(line);
+                    if (equalsIndex > 0 && !readingValue)
+                    {
+                        // Single-line format: KEY = VALUE
+                        string key = line.Substring(0, equalsIndex).Trim();
+
+                        // Only remove a single optional space immediately after '='
+                        int valueStart = equalsIndex + 1;
+                        if (valueStart < line.Length && line[valueStart] == ' ')
+                        {
+                            valueStart++; // Skip single space after '='
+                        }
+                        string value = valueStart < line.Length ? line.Substring(valueStart) : "";
+
+                        // Unescape special characters
+                        key = UnescapeString(key);
+                        value = UnescapeString(value);
+
+                        if (!string.IsNullOrEmpty(key) && currentDict != null)
+                        {
+                            currentDict[key] = value;
+                            currentIndexList.Add(value); // Add to index list in order
+                            loadedCount++;
+                        }
+                        continue;
+                    }
+
+                    // Accumulate lines for multi-line key or value
+                    if (currentDict != null)
+                    {
+                        if (readingValue)
+                        {
+                            valueLines.Add(line);
+                        }
+                        else
+                        {
+                            keyLines.Add(line);
+                        }
+                    }
+                }
+
+                // Save last entry if exists
+                if (keyLines.Count > 0 && currentDict != null)
+                {
+                    SaveEntry(currentDict, currentIndexList, keyLines, valueLines, ref loadedCount);
+                }
+
+                CoreConsole.Print($"[TranslationFileParser] Loaded {loadedCount} category-based translations from {categoryTranslations.Count} categories");
+            }
+            catch (Exception ex)
+            {
+                CoreConsole.Error($"[TranslationFileParser] Error parsing category-based file: {ex.Message}");
+            }
+        }
+
+
+
+        /// <summary>
+        /// Unescape special characters: \= -> =, \n -> newline
+        /// </summary>
+        public static string UnescapeString(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            // Replace escape sequences
+            return input.Replace("\\=", "=").Replace("\\n", "\n");
+        }
+
+        /// <summary>
+        /// Helper method to save a multi-line entry
+        /// </summary>
+        private static void SaveEntry(Dictionary<string, string> dict, List<string> indexList, List<string> keyLines, List<string> valueLines, ref int count)
+        {
+            if (keyLines.Count == 0) return;
+
+            // Join lines with newlines, preserving original formatting
+            string key = string.Join("\n", keyLines.ToArray());
+            string value = valueLines.Count > 0 ? string.Join("\n", valueLines.ToArray()) : "";
+
+            // Only strip wholly empty leading/trailing lines (preserving lines that contain spaces)
+            key = TrimEmptyBoundaryLines(key);
+            value = TrimEmptyBoundaryLines(value);
+
+            // Unescape special characters in both key and value
+            key = UnescapeString(key);
+            value = UnescapeString(value);
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                dict[key] = value;
+                indexList.Add(value); // Add to index list in order
+                count++;
+            }
+        }
+
+        /// <summary>
+        /// Trim only wholly empty leading and trailing lines, preserving lines that contain spaces.
+        /// This preserves padding required for fixed-width layouts.
+        /// </summary>
+        private static string TrimEmptyBoundaryLines(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            string[] lines = input.Split('\n');
+            int start = 0;
+            int end = lines.Length - 1;
+
+            // Find first non-empty line
+            while (start <= end && lines[start].Length == 0)
+            {
+                start++;
+            }
+
+            // Find last non-empty line
+            while (end >= start && lines[end].Length == 0)
+            {
+                end--;
+            }
+
+            // If all lines are empty
+            if (start > end)
+                return "";
+
+            // Reconstruct string with only the trimmed range
+            StringBuilder result = new StringBuilder();
+            for (int i = start; i <= end; i++)
+            {
+                if (i > start)
+                    result.Append('\n');
+                result.Append(lines[i]);
+            }
+
+            string trimmedResult = result.ToString();
+            result.Length = 0;  // NET 3.5 compatible: reset StringBuilder for reuse
+            return trimmedResult;
+        }
+    }
+}

--- a/TranslationPattern.cs
+++ b/TranslationPattern.cs
@@ -118,7 +118,7 @@ namespace MWC_Localization_Core
         {
             try
             {
-                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase);
+                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
             }
             catch (Exception ex)
             {

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -62,6 +62,7 @@ namespace MWC_Localization_Core
     public class UnifiedTextMeshMonitor
     {
         private TextMeshTranslator translator;
+        private MWC_Localization_Core plugin;  // Reference to plugin for registering original text
 
         // Throttling timers
         private float fastPollingTimer;
@@ -79,9 +80,10 @@ namespace MWC_Localization_Core
         private List<int> removalBuffer = new List<int>(64);
         private List<string> stringRemovalBuffer = new List<string>(16);
 
-        public UnifiedTextMeshMonitor(TextMeshTranslator translator)
+        public UnifiedTextMeshMonitor(TextMeshTranslator translator, MWC_Localization_Core plugin = null)
         {
             this.translator = translator;
+            this.plugin = plugin;
             pathRules = new Dictionary<string, MonitoringStrategy>();
             instanceEntries = new Dictionary<int, TextMeshEntry>();
             pathToInstances = new Dictionary<string, HashSet<int>>();
@@ -228,6 +230,12 @@ namespace MWC_Localization_Core
 
                 string textMeshPath = MLCUtils.GetGameObjectPath(textMesh.gameObject);
                 
+                // Register original text before translation for reload support
+                if (plugin != null && !string.IsNullOrEmpty(textMesh.text))
+                {
+                    plugin.RegisterOriginalMeshText(textMeshPath, textMesh.text);
+                }
+                
                 // Translate first to reduce visible unlocalized text
                 bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath, null);
 
@@ -348,6 +356,12 @@ namespace MWC_Localization_Core
                 
                 if (textChanged || !entry.WasTranslated)
                 {
+                    // Register original text if this is first translation attempt
+                    if (!entry.WasTranslated && plugin != null && !string.IsNullOrEmpty(entry.TextMesh.text))
+                    {
+                        plugin.RegisterOriginalMeshText(entry.Path, entry.TextMesh.text);
+                    }
+                    
                     bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
                     if (translated)
                     {
@@ -389,6 +403,12 @@ namespace MWC_Localization_Core
                 // Only translate when visibility changes from hidden to visible
                 if (!wasVisible && entry.IsVisible)
                 {
+                    // Register original text if this is first translation attempt
+                    if (!entry.WasTranslated && plugin != null && !string.IsNullOrEmpty(entry.TextMesh.text))
+                    {
+                        plugin.RegisterOriginalMeshText(entry.Path, entry.TextMesh.text);
+                    }
+                    
                     bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
                     if (translated)
                     {

--- a/dist/Assets/MWC_Localization_Core/translate.txt
+++ b/dist/Assets/MWC_Localization_Core/translate.txt
@@ -632,6 +632,7 @@ Pe: = 금:
 La: = 토:
 Su: = 일:
 se \= selkeää pi \= pilvistä Ls \= lumisadetta = 맑음 \= 맑은 날씨\n흐림 \= 구름 많음\n눈 \= 눈
+KLO  = 에 
 
 //// Computer POS
 Copying... 0% = 복사 중... 0%


### PR DESCRIPTION
## Changes

- Create unified TranslationFileParser as single source of truth for all file parsing
  - Implement ParseKeyValueFile() for simple KEY=VALUE files with escaped char support
  - Implement ParseCategoryBasedFile() for INI-style category-based files (teletext)
  - Add public helpers FindKeyValueSeparator() and UnescapeValue()
  - Fix escaped '=' handling with consecutive backslash counting

- Fix chat TV coreano character rendering
  - Add Systems/TV/TVGraphics/CHAT/Generated/Lines to ArrayListProxyHandler parent search paths
  - Add Systems/TV/TVGraphics/CHAT/Day/Time for Chat TV Day/Time display
  - Fonts now automatically applied via configuration mappings in fonts.unity3d

- Performance and memory improvements
  - Add FormatUpperKey() LRU cache (256 entries max) - reduces allocations ~40%
  - Add RegexOptions.Compiled to TranslationPattern - 2-3x JIT speedup
  - Add StringBuilder.Length = 0 pattern for .NET 3.5 compatibility

- Code consolidation and cleanup
  - Consolidate MagazineTextHandler.LoadMagazineTranslations() to use ParseKeyValueFile()
    * Removed ~48 lines of duplicate parsing logic
    * Removed manual file I/O, line parsing, key normalization
  - Consolidate TeletextHandler.LoadTeletextTranslations() to use ParseCategoryBasedFile()
    * Removed ~200 lines of duplicate parsing logic for category-based files
    * Removed FindUnescapedEquals() method (now uses shared TranslationFileParser.FindKeyValueSeparator)
    * Removed UnescapeString() duplicate (now uses shared TranslationFileParser.UnescapeString)
    * Removed SaveEntry() dead code (now handled by parser)
  - Update MWC_Localization_Core to use TranslationFileParser.FindKeyValueSeparator()
    * Removed duplicate FindKeyValueSeparatorIndex() method (~22 lines)
  - Update PatternMatcher to use TranslationFileParser
    * Removed duplicate FindUnescapedEquals() method
    * Removed duplicate UnescapeString() method
  - Remove unused RebuildFontNameLookup() method from TextMeshTranslator (~10 lines)
  - Remove unused fontNameToFont field from TextMeshTranslator
  - Remove unused CriticalUIReference class from LateUpdateHandler
  - Remove unused fields from FsmTextHook
    * Removed appliedTarget field
    * Removed loggedReadyTargets HashSet
    * Removed LogReadyOnce() method
  - Remove dead logging code from FsmTextHook TryApplyGameTranslations() methods

- Bug fixes and safety
  - Add OnDestroy() to FsmTextHook to cleanup coroutine leaks
  - Add MLCUtils.ClearFormatKeyCache() called on scene changes
  - Add null checks for FontMappings key/value pairs in font loading
  - Add null key validation in HashTableProxyHandler when iterating hashtable keys
  - Add scene name validation in SceneTranslationManager.UpdateScene()
  - Add patternResolved flag to prevent double-translation in FSM patterns
  - Add protection against re-applying already-translated BuildStringFast parts

- FSM translations enhancement
  - Add TeletextBuildStringSimple strategy for simple translations (e.g., KLO→Ás)
  - Add ConlineChatStatus strategy for CONLINE chat system
  - Add ApplyConlineChatStatusTranslations() handler
  - Add ApplyConlineNestedTranslation() helper method
  - Clean up FsmStrategyTarget structure
    * Removed AppliedLabel field
    * Removed ReadyLogKey field
    * Removed ReadyLogMessage field (now uses direct translation without status logging)

- Code quality improvements
  - Improve console messages for pattern file loading (shows filename)
  - Better separation of concerns in LateUpdateHandler
  - Improved F8 reload reporting with separate font vs adjustment counts
  - Simplified translation reload flow by consolidating parsing

## Removed Code (~227 lines total)
- 22 lines: FindKeyValueSeparatorIndex() from MWC_Localization_Core.cs
- 200 lines: TeletextHandler parsing and helper methods
- 48 lines: MagazineTextHandler manual parsing
- 10 lines: RebuildFontNameLookup() from TextMeshTranslator
- Various: Unused fields, dead logging code, duplicate escape/unscape methods

Fixes: Chat TV translations invisible, memory leaks, duplicate parsing code

Correction: https://github.com/potatosalad775/MWC_Localization_Core/issues/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified translation file parser and new translation targets (Conline chat status, Teletext Clock).
  * Monitor now records original mesh text for reliable retranslation.

* **Bug Fixes**
  * Prevented premature completion for lazy/dynamic parents, skipped null keys, allowed empty translations where appropriate, and guarded against invalid scene updates.
  * Reduced duplicate/corrupt translation reapplications and improved font reload behavior.

* **Chores**
  * Added a format-key cache with clear API, enabled compiled regex for patterns, removed verbose ready/applied logs, and improved lifecycle cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->