### PR TITLE
fix: FSM double-translation, scene/coroutine cleanup, null-safety, new FSM targets

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -304,9 +304,10 @@ namespace MWC_Localization_Core
                     }
                 }
 
-                // Mark this parent path as complete if we found the parent and processed all its TextMeshes
-                // (If anyNewFonts is false, it means all TextMeshes were already processed)
-                if (!anyNewFonts)
+                // Only mark this parent path as complete if we actually found TextMeshes under it
+                // and none of them produced a new font application. If textMeshes.Length == 0 the
+                // parent exists but children haven't been lazy-loaded yet - retry on the next tick.
+                if (textMeshes.Length > 0 && !anyNewFonts)
                 {
                     completedParentPaths.Add(parentPath);
                 }

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -14,6 +14,7 @@ namespace MWC_Localization_Core
     {
         private Dictionary<string, string> translations;
         private GameObject hostObject;
+        private Coroutine applyWhenReadyCoroutine;
         private PatternMatcher patternMatcher;
         private string appliedTarget;
         private HashSet<string> loggedReadyTargets = new HashSet<string>();
@@ -50,8 +51,10 @@ namespace MWC_Localization_Core
             PosUse,
             PosTyper,
             TeletextBuildStringPattern,
+            TeletextBuildStringSimple,
             TeletextWeatherUpdaterTokens,
-            UnemployPaperButtonVariables
+            UnemployPaperButtonVariables,
+            ConlineChatStatus
         }
 
         private sealed class FsmStrategyTarget
@@ -148,7 +151,18 @@ namespace MWC_Localization_Core
                 "TTX_DATA_READY",
                 "[FsmTextHook] Teletext Data FSM bottomline targets are ready.",
                 "State 1",
-                3)
+                3),
+            // Chat-TV clock label (e.g. "KLO" prefix) uses a BuildString action; only part[0]
+            // should be translated - the other parts hold dynamic time/date values.
+            new FsmStrategyTarget(
+                "Systems/TV/TVGraphics/CHAT/Day/Time",
+                "Clock",
+                FsmStrategyType.TeletextBuildStringSimple,
+                "GAME Teletext Clock",
+                "TTX_CLOCK_READY",
+                "[FsmTextHook] Teletext Clock FSM target is ready.",
+                "State 3",
+                2)
         };
 
         private static readonly string TeletextEnnusteUpdaterPrefix = "Systems/TV/Teletext/VKTekstiTV/PAGES/188/Texts/Updater/Ennuste/";
@@ -202,6 +216,23 @@ namespace MWC_Localization_Core
             return targets.ToArray();
         }
 
+        // CONLINE chat-status target: FSM nested setProperty on Download/Fail states that
+        // pushes status strings (e.g. "ONLINE", "CALL FAILED") into an FsmString on the
+        // chat-TV UI. The nested reflection doesn't always resolve on the first ready check,
+        // so this strategy is intentionally retried until it actually makes a change.
+        private static readonly FsmStrategyTarget[] GameConlineTargets = new FsmStrategyTarget[]
+        {
+            new FsmStrategyTarget(
+                "COMPUTER/SYSTEM/TELEBBS/CONLINE/CHAT",
+                "Type",
+                FsmStrategyType.ConlineChatStatus,
+                "GAME Conline Chat",
+                "CONLINE_CHAT_READY",
+                "[FsmTextHook] Conline Chat FSM target is ready.",
+                null,
+                -1)
+        };
+
         public void Initialize(Dictionary<string, string> translations, GameObject hostObject, string[] patternFiles)
         {
             this.translations = translations;
@@ -220,7 +251,7 @@ namespace MWC_Localization_Core
                 }
             }
 
-            StartCoroutine(ApplyWhenReady());
+            applyWhenReadyCoroutine = StartCoroutine(ApplyWhenReady());
         }
 
         private IEnumerator ApplyWhenReady()
@@ -265,6 +296,7 @@ namespace MWC_Localization_Core
             anyChanged |= TryApplyGameTeletextBottomlineFsmTranslations();
             anyChanged |= TryApplyGameTeletextWeatherUpdaterFsmTranslations();
             anyChanged |= TryApplyGameUnemployPaperFsmTranslations();
+            anyChanged |= TryApplyGameConlineChatFsmTranslations();
 
             if (anyChanged)
             {
@@ -380,6 +412,21 @@ namespace MWC_Localization_Core
             return anyChanged || hasAnyTarget;
         }
 
+        private bool TryApplyGameConlineChatFsmTranslations()
+        {
+            bool anyChanged = false;
+            bool hasAnyTarget = false;
+
+            ApplyStrategyTargets(GameConlineTargets, ref anyChanged, ref hasAnyTarget);
+
+            if (anyChanged)
+            {
+                appliedTarget = "GAME Conline Chat";
+            }
+
+            return anyChanged || hasAnyTarget;
+        }
+
         private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged, ref bool hasAnyTarget)
         {
             if (targets == null || targets.Length == 0)
@@ -400,8 +447,18 @@ namespace MWC_Localization_Core
                     continue;
 
                 LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
-                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
-                completedStrategyTargets.Add(targetKey);
+
+                bool strategyChanged;
+                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget, out strategyChanged);
+
+                // ConlineChatStatus reaches through nested FsmString properties and may not
+                // succeed on the first ready check even when the FSM reports Initialized.
+                // Keep retrying that strategy until it actually translates something; every
+                // other strategy is fine to mark complete immediately.
+                if (strategyChanged || target.Strategy != FsmStrategyType.ConlineChatStatus)
+                {
+                    completedStrategyTargets.Add(targetKey);
+                }
             }
         }
 
@@ -410,10 +467,13 @@ namespace MWC_Localization_Core
             return target.ObjectPath + "|" + target.FsmName + "|" + target.Strategy.ToString() + "|" + target.StateName + "|" + target.ActionIndex.ToString();
         }
 
-        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
+        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget, out bool strategyChanged)
         {
+            strategyChanged = false;
             if (target == null || fsm == null)
                 return;
+
+            bool beforeChanged = anyChanged;
 
             switch (target.Strategy)
             {
@@ -447,6 +507,13 @@ namespace MWC_Localization_Core
                     hasAnyTarget |= HasState(fsm, target.StateName);
                     break;
 
+                case FsmStrategyType.TeletextBuildStringSimple:
+                    // Translate only part[0] (e.g. "KLO " -> localized prefix) and leave the
+                    // dynamic time/date parts 1 and 2 untouched.
+                    anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, target.StateName, target.ActionIndex, false, 1, 2);
+                    hasAnyTarget |= HasState(fsm, target.StateName);
+                    break;
+
                 case FsmStrategyType.TeletextWeatherUpdaterTokens:
                     ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
                     break;
@@ -455,12 +522,19 @@ namespace MWC_Localization_Core
                     anyChanged |= ApplyUnemployPaperButtonVariableTranslations(fsm);
                     hasAnyTarget = true;
                     break;
+
+                case FsmStrategyType.ConlineChatStatus:
+                    anyChanged |= ApplyConlineChatStatusTranslations(fsm);
+                    hasAnyTarget = true;
+                    break;
             }
 
             if (anyChanged && !string.IsNullOrEmpty(target.AppliedLabel))
             {
                 appliedTarget = target.AppliedLabel;
             }
+
+            strategyChanged = (anyChanged != beforeChanged);
         }
 
         private void LogReadyOnce(string key, string message)
@@ -504,6 +578,66 @@ namespace MWC_Localization_Core
             changed |= TranslateFsmStringVariableExact(fsm, "JobYes");
 
             return changed;
+        }
+
+        // Translate status strings written into a nested FsmString via setProperty actions
+        // inside the CHAT/Type FSM (Download + Fail states).
+        private bool ApplyConlineChatStatusTranslations(PlayMakerFSM fsm)
+        {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
+            bool changed = false;
+            changed |= ApplyConlineNestedTranslation(fsm, "Download", 1);
+            changed |= ApplyConlineNestedTranslation(fsm, "Fail", 0);
+            return changed;
+        }
+
+        private bool ApplyConlineNestedTranslation(PlayMakerFSM fsm, string stateName, int actionIndex)
+        {
+            if (fsm == null || fsm.FsmStates == null)
+                return false;
+
+            HutongGames.PlayMaker.FsmState state = null;
+            for (int i = 0; i < fsm.FsmStates.Length; i++)
+            {
+                if (fsm.FsmStates[i] != null && fsm.FsmStates[i].Name == stateName)
+                {
+                    state = fsm.FsmStates[i];
+                    break;
+                }
+            }
+
+            if (state == null || state.Actions == null || actionIndex < 0 || actionIndex >= state.Actions.Length)
+                return false;
+
+            object action = state.Actions[actionIndex];
+            if (action == null)
+                return false;
+
+            FieldInfo targetPropertyField = GetCachedField(action.GetType(), "targetProperty");
+            if (targetPropertyField == null)
+                return false;
+
+            object targetProperty = targetPropertyField.GetValue(action);
+            if (targetProperty == null)
+                return false;
+
+            FieldInfo stringParamField = GetCachedField(targetProperty.GetType(), "StringParameter");
+            if (stringParamField == null)
+                return false;
+
+            HutongGames.PlayMaker.FsmString fsmString = stringParamField.GetValue(targetProperty) as HutongGames.PlayMaker.FsmString;
+            if (fsmString == null || string.IsNullOrEmpty(fsmString.Value))
+                return false;
+
+            string original = fsmString.Value;
+            string translated = GetTranslation(original, original);
+            if (translated == original)
+                return false;
+
+            fsmString.Value = translated;
+            return true;
         }
 
         private bool TranslateFsmStringVariableExact(PlayMakerFSM fsm, string variableName)
@@ -718,17 +852,26 @@ namespace MWC_Localization_Core
                 return false;
 
             bool changed = false;
+            bool patternResolved = false;
             if (allowPatternSplit && isBuildStringFast)
             {
-                changed = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts);
+                patternResolved = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts);
+                changed = patternResolved;
             }
 
-            for (int i = 0; i < parts.Length; i++)
+            // If the pattern path rewrote parts[0]/parts[2] around parts[1], DON'T then
+            // run per-part translation - it would double-translate the already rewritten
+            // prefix/suffix and corrupt the result. Only fall back to per-part when no
+            // pattern matched.
+            if (!patternResolved)
             {
-                if (ShouldSkipIndex(i, skipPartIndexes))
-                    continue;
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    if (ShouldSkipIndex(i, skipPartIndexes))
+                        continue;
 
-                changed |= TranslateStringPart(parts[i]);
+                    changed |= TranslateStringPart(parts[i]);
+                }
             }
 
             return changed;
@@ -765,6 +908,16 @@ namespace MWC_Localization_Core
 
             string newPrefix = translatedCombined.Substring(0, middleIndex);
             string newSuffix = translatedCombined.Substring(middleIndex + middleValue.Length);
+
+            // If parts[0]/parts[2] already match the translated prefix/suffix, the pattern
+            // has already been applied on a previous tick. Return true so the caller still
+            // treats this as "pattern-resolved" (skipping per-part translation) without
+            // needlessly writing back identical values.
+            string currentPart0 = part0.Value ?? string.Empty;
+            string currentPart2 = part2.Value ?? string.Empty;
+            if (currentPart0 == newPrefix && currentPart2 == newSuffix)
+                return true;
+
             bool changed = false;
 
             if (part0.Value != newPrefix)
@@ -1050,6 +1203,24 @@ namespace MWC_Localization_Core
         {
             if (hostObject != null)
                 Object.Destroy(hostObject);
+        }
+
+        private void OnDestroy()
+        {
+            // Stop the still-running ApplyWhenReady coroutine so it doesn't keep polling
+            // (and holding references to translations/hostObject) after this hook is torn
+            // down - e.g. on scene change or F8 reload.
+            if (applyWhenReadyCoroutine != null)
+            {
+                StopCoroutine(applyWhenReadyCoroutine);
+                applyWhenReadyCoroutine = null;
+            }
+
+            if (hostObject != null)
+            {
+                Object.Destroy(hostObject);
+                hostObject = null;
+            }
         }
     }
 }

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -142,12 +142,16 @@ namespace MWC_Localization_Core
             List<object> keys = new List<object>();
             foreach (object key in hashTable.Keys)
             {
+                if (key == null)
+                    continue;
                 keys.Add(key);
             }
 
             for (int i = 0; i < keys.Count; i++)
             {
                 object key = keys[i];
+                if (key == null)
+                    continue;
                 string original = hashTable[key] as string;
                 if (string.IsNullOrEmpty(original))
                     continue;

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -217,6 +217,15 @@ namespace MWC_Localization_Core
                     lateUpdateHandlerObject = null;
                     lateUpdateHandler = null;
                 }
+
+                // Tear down the FSM hook when leaving MainMenu/GAME so its coroutine
+                // doesn't keep polling in scenes that have no FSM targets.
+                if (currentScene != "MainMenu" && currentScene != "GAME" && fsmTextHookObject != null)
+                {
+                    Object.Destroy(fsmTextHookObject);
+                    fsmTextHookObject = null;
+                }
+
                 CoreConsole.Print($"[{Name}] Scene changed to '{currentScene}' - cleared caches");
             }
 
@@ -294,6 +303,9 @@ namespace MWC_Localization_Core
 
                 foreach (var pair in config.FontMappings)
                 {
+                    if (string.IsNullOrEmpty(pair.Key) || string.IsNullOrEmpty(pair.Value))
+                        continue;
+
                     Font font = fontBundle.LoadAsset(pair.Value, typeof(Font)) as Font;
                     if (font != null)
                     {
@@ -469,11 +481,15 @@ namespace MWC_Localization_Core
             // Reset managers
             sceneManager.ResetAll();
             textMeshMonitor.Clear();
-            
+
             // Reset teletext handler
             teletextHandler.Reset();
             arrayListHandler.Reset();
             hashTableHandler.Reset();
+
+            // Reload custom font mappings from config so edits to FontMappings take effect.
+            customFonts.Clear();
+            LoadCustomFonts();
 
             // Reapply fonts and adjustments to all TextMeshes (after restore)
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
@@ -498,7 +514,11 @@ namespace MWC_Localization_Core
                 InitializeFsmTextHook();
             }
 
-            CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts/adjustments to {reappliedCount} TextMeshes.");
+            int totalTranslationsReloaded = translations.Count
+                + magazineHandler.GetTranslationCount()
+                + teletextHandler.GetTranslationCount();
+
+            CoreConsole.Print($"[{Name}] [F8] Reloaded {totalTranslationsReloaded} translations. Reapplied fonts/adjustments to {reappliedCount} TextMeshes.");
         }
 
         void InitializeFsmTextHook()

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -26,6 +26,14 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Get total count of loaded magazine translations
+        /// </summary>
+        public int GetTranslationCount()
+        {
+            return magazineTranslations.Count;
+        }
+
+        /// <summary>
         /// Check if path is a magazine text element
         /// </summary>
         public bool IsMagazineText(string path)

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -63,6 +63,9 @@ namespace MWC_Localization_Core
         /// </summary>
         public bool UpdateScene(string newScene)
         {
+            if (string.IsNullOrEmpty(newScene))
+                return false;
+
             if (currentScene != newScene)
             {
                 previousScene = currentScene;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -29,6 +29,9 @@ namespace MWC_Localization_Core
         
         // Track which arrays have been translated already
         private HashSet<string> translatedArrays = new HashSet<string>();
+
+        // Total translations loaded on the most recent LoadTeletextTranslations call.
+        private int lastLoadedTranslationCount = 0;
         
         // GameObject path to category mapping
         private Dictionary<string, string> pathPrefixes = new Dictionary<string, string>
@@ -65,6 +68,20 @@ namespace MWC_Localization_Core
             {
                 categoryTranslations["ChatMessages.Messages"] = chatAllDict;
             }
+
+            lastLoadedTranslationCount = 0;
+            foreach (var category in categoryTranslations.Values)
+            {
+                lastLoadedTranslationCount += category.Count;
+            }
+        }
+
+        /// <summary>
+        /// Get total count of loaded teletext translations (sum across categories).
+        /// </summary>
+        public int GetTranslationCount()
+        {
+            return lastLoadedTranslationCount;
         }
 
         /// <summary>

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -63,10 +63,17 @@ namespace MWC_Localization_Core
             categoryTranslations = loadedCategoryTranslations;
             indexBasedTranslations = loadedIndexBasedTranslations;
 
-            // Create alias: ChatMessages.Messages uses ChatMessages.All translations
+            // Create alias: ChatMessages.Messages uses ChatMessages.All translations.
+            // Mirror the alias on the index-based map too so the ordered fallback in
+            // TranslateArrayListProxy works for ChatMessages.Messages - otherwise entries
+            // that don't exact-match by key fall through with no translation at all.
             if (categoryTranslations.TryGetValue("ChatMessages.All", out Dictionary<string, string> chatAllDict))
             {
                 categoryTranslations["ChatMessages.Messages"] = chatAllDict;
+            }
+            if (indexBasedTranslations.TryGetValue("ChatMessages.All", out List<string> chatAllList))
+            {
+                indexBasedTranslations["ChatMessages.Messages"] = chatAllList;
             }
 
             lastLoadedTranslationCount = 0;

--- a/TranslationPattern.cs
+++ b/TranslationPattern.cs
@@ -118,7 +118,7 @@ namespace MWC_Localization_Core
         {
             try
             {
-                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase);
+                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Follow-up to the merged #62 parser refactor. Collects the non-feature bug fixes, null-safety, and small new FSM-target coverage that the author bundled into #61, plus one pre-existing latent bug surfaced during review.

All logic here is lifted (with minor cleanup) from @LucasMonFC's work in #61.

## What's in this PR

### Bug fixes

- **FSM double-translation (`FsmTextHook.ApplyBuildStringActionStringPartsTranslation`)** — when pattern translation rewrote `parts[0]` / `parts[2]` around `parts[1]`, the subsequent per-part loop would run again over the already-rewritten prefix/suffix and corrupt them. New `patternResolved` flag skips the per-part loop when a pattern already resolved the combined text.
- **Redundant pattern writes (`FsmTextHook.ApplyBuildStringFastPatternTranslation`)** — on a retick where `parts[0]` / `parts[2]` already match the translated prefix/suffix, short-circuit to "pattern resolved, no write" instead of writing the same values back.
- **Coroutine leak on teardown (`FsmTextHook`)** — store the `ApplyWhenReady` coroutine handle, stop it in a new `OnDestroy()` so it doesn't keep polling after the hook is torn down on scene change / F8 reload.
- **FSM hook polling in unrelated scenes (`MWC_Localization_Core`)** — destroy `fsmTextHookObject` when leaving `MainMenu` / `GAME` so the polling coroutine doesn't stay alive in scenes that have no FSM targets.
- **F8 reload ignores font-mapping edits (`MWC_Localization_Core.ReloadTranslations`)** — clear `customFonts` and call `LoadCustomFonts()` before reapplying so edits to `FontMappings` in `config.txt` actually take effect.
- **Lazy-loaded children marked as "complete" (`ArrayListProxyHandler.ApplyFontsToArrayElements`)** — previously a parent path was marked complete as soon as a lookup returned zero TextMeshes, even if the parent GameObject existed and its children just hadn't been spawned yet. Now we only mark complete when `textMeshes.Length > 0 && !anyNewFonts`.
- **`ChatMessages.Messages` index-based fallback disabled (`TeletextHandler.LoadTeletextTranslations`)** — pre-existing bug. The alias was only mirrored on `categoryTranslations`, so `TranslateArrayListProxy`'s ordered fallback (via `indexBasedTranslations`) was disabled for `ChatMessages.Messages` and any runtime chat line that didn't exact-match by key fell through with no translation. Mirror the alias on `indexBasedTranslations` too.
- **Null-safety** — guard null keys in `HashTableProxyHandler.TranslateProxy` (both while building the keys list and while iterating it), guard null/empty scene names in `SceneTranslationManager.UpdateScene`, skip null/empty `FontMappings` pair entries in `LoadCustomFonts`.

### New FSM-target coverage

- **`FsmStrategyType.TeletextBuildStringSimple`** with a Chat-TV Clock target (`Systems/TV/TVGraphics/CHAT/Day/Time`, FSM `Clock`, State 3 / action 2). Translates only `part[0]` (e.g. `KLO ` → localized prefix) and leaves the dynamic time / date parts 1 and 2 alone.
- **`FsmStrategyType.ConlineChatStatus`** with a `COMPUTER/SYSTEM/TELEBBS/CONLINE/CHAT` / `Type` target and `ApplyConlineChatStatusTranslations` / `ApplyConlineNestedTranslation` helpers that walk `setProperty` → `targetProperty.StringParameter` on the `Download` and `Fail` states.
- `ApplyStrategyTargets` / `ApplyStrategyForTarget` now report per-strategy change status so `ConlineChatStatus` (which reaches through nested FSM reflection and doesn't always resolve on the first ready check) is retried until it actually translates, while every other strategy still marks complete immediately.

### Perf / diagnostics

- `TranslationPattern` — compile regex with `RegexOptions.Compiled | RegexOptions.IgnoreCase` for faster match-time performance.
- `MagazineTextHandler` / `TeletextHandler` — expose `GetTranslationCount()` (plus `lastLoadedTranslationCount` in TeletextHandler) so the F8 reload log can report the actual aggregate (`main + magazine + teletext`) instead of just `translations.Count`.

## What's intentionally **not** in this PR

The following pieces of #61 were left out; see the discussion on #61 for the full reasoning.

- `originalMeshText` dictionary + `RegisterOriginalMeshText` + the F8 retranslation loop that depends on it. The `Clear()`-before-read ordering made the retranslation block dead code, the path-keyed storage is fragile for dynamic content, and with `customFonts.Clear() + LoadCustomFonts()` on F8 the feature it was trying to enable isn't needed to get font-mapping edits to apply.
- `MLCUtils.FormatUpperKey` bounded cache + `ClearFormatKeyCache`. The 256-entry add-only cache (misdocumented as "LRU") doesn't reliably cache the hot strings because it fills with whichever strings are seen first after a scene change.
- `textMeshCache` in `ArrayListProxyHandler` — caching `GetComponentsInChildren<TextMesh>` with no invalidation breaks dynamic-child discovery.
- `dynamicParentPaths` HashSet + the new `CHAT/Generated/Lines` and `CHAT/Day/Time` entries in `parentSearchPaths`. `UnifiedTextMeshMonitor` already covers those paths (`CHAT/Generated` as `LateTranslateOnce`, `CHAT/Day` as `FastPolling`); the chat lines shift existing TextMeshes rather than spawning new ones, so the dedicated font-application loop isn't needed.
- Removal of `RebuildFontNameLookup` / `fontNameToFont` — keeping the O(1) reverse lookup over the O(n) foreach scan.
- Removal of the `LogReadyOnce` / `AppliedLabel` / `ReadyLogKey` / `ReadyLogMessage` diagnostic logging — kept as-is; the new Clock / CONLINE targets have their own ready-log messages wired up.
- Removal of the initial per-file `"Loaded N translations from <file>"` log — kept.

## Test plan

- [ ] Build succeeds.
- [ ] Load into `GAME`, go near the Chat TV; the clock prefix renders in the localized font and text (e.g. `KLO` → localized) while the time and date continue to update correctly.
- [ ] Start a CONLINE chat session from the PC; the `Download` / `Fail` status strings display translated text.
- [ ] Verify existing Teletext bottomlines and POS terminal still translate — regression check on the `patternResolved` flag.
- [ ] Verify `ChatMessages.Messages` runtime chat lines translate via the ordered fallback when the exact-match lookup misses.
- [ ] Press F8 to reload. Edit a font mapping in `config.txt`, reload again, and confirm the new mapping is applied.
- [ ] Leave `GAME` back to `MainMenu` or intermediate scene; confirm `[FsmTextHook]` polling log messages stop.
- [ ] Confirm the F8 log line reports the aggregate translation count (`main + magazine + teletext`).

## Attribution

All of the logic here is lifted (with minor cleanup) from @LucasMonFC's work in #61, except the `ChatMessages.Messages` index-based alias mirror which was surfaced during review of #62 as a pre-existing latent bug.

https://claude.ai/code/session_01LvZja9uuy5jTABjtGMWfBj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended translation support for chat system messaging.

* **Bug Fixes**
  * Fixed lazy-loaded content handling and null value processing during translations.
  * Improved scene transition validation.
  * Enhanced font loading robustness with null-check safeguards.
  * Prevented unintended duplicate translations.
  * Added proper cleanup on scene changes.

* **Performance**
  * Optimized pattern matching with compiled regex.
  * Expanded hot-reload to refresh font mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->