### PR TITLE
fix: F8-reload compile error + dead-code/log cleanup

### DIFF
--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -17,16 +17,6 @@ namespace MWC_Localization_Core
         private ArrayListProxyHandler arrayListHandler;
         private HashTableProxyHandler hashTableHandler;
         private SceneTranslationManager sceneManager;
-        
-        // Cached references for critical UI (EveryFrame monitoring)
-        private class CriticalUIReference
-        {
-            public string Path;
-            public TextMesh TextMesh;
-            public int RetryCount;
-            public float NextRetryTime;
-            public bool IsRegistered;
-        }
 
         private bool isInitialized = false;
         

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -469,10 +469,9 @@ namespace MWC_Localization_Core
                 lateUpdateHandler.ClearCache();
                 // Re-initialize to find critical UI components again
                 lateUpdateHandler.Initialize(
-                    translator, 
-                    textMeshMonitor, 
-                    teletextHandler, 
-                    arrayListHandler, 
+                    textMeshMonitor,
+                    teletextHandler,
+                    arrayListHandler,
                     hashTableHandler,
                     sceneManager
                 );

--- a/PatternMatcher.cs
+++ b/PatternMatcher.cs
@@ -117,7 +117,8 @@ namespace MWC_Localization_Core
                     }
                 }
 
-                CoreConsole.Print($"[PatternMatcher] Loaded {loadedCount} patterns from file");
+                string fileName = Path.GetFileName(filePath);
+                CoreConsole.Print($"[PatternMatcher] Loaded {loadedCount} patterns from {fileName}");
             }
             catch (System.Exception ex)
             {


### PR DESCRIPTION
## Summary

Three small fixes that surfaced while investigating the chat-font issue.

### 1. Fix stale `translator` arg in F8-reload path (`MWC_Localization_Core.cs:471`)
Commit `5ff4080` removed the `translator` parameter from `LateUpdateHandler.Initialize` and updated the *first* call site (around line 170), but missed the *second* call site inside the F8-reload path. That site still passed `translator` as the first positional argument, so the reload code path no longer compiled against the current `Initialize` signature. Drops the stale arg.

### 2. Remove dead `CriticalUIReference` class (`LateUpdateHandler.cs`)
The class is defined but never instantiated or referenced anywhere in the codebase. Its 5 public fields (`Path`, `TextMesh`, `RetryCount`, `NextRetryTime`, `IsRegistered`) trigger CS0649 ("field is never assigned") warnings on every build. Deleting the class removes all 5 warnings.

### 3. Include source filename in PatternMatcher load log (`PatternMatcher.cs`)
`LoadPatternsFromFile` is called once per pattern file (e.g., `translate_teletext.txt`, `translate_mod.txt`) but the success log just said `Loaded N patterns from file`. When a reload (F8) prints several of these in a row, there's no way to tell which file produced which count. Now logs `Loaded N patterns from <fileName>`.

## Test plan
- [ ] Build succeeds (no CS0117 from the F8-reload site, no CS0649 from `LateUpdateHandler.cs`)
- [ ] In-game F8 reload no longer fails / hits the broken Initialize path
- [ ] In-game F8 reload prints `[PatternMatcher] Loaded ... patterns from <filename>` once per loaded pattern file with the correct filename

https://claude.ai/code/session_013cG1H4EUg9CasK5MXWCaHs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal structures to improve maintainability.

* **Chores**
  * Improved pattern-load logging to include source file names for better diagnostics.
  * Cleaned up initialization call formatting for clearer, more consistent code style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->