### PR TITLE
fix: apply localized font to upstream-translated CHAT/Generated TextMeshes

### DIFF
--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -46,6 +46,14 @@ namespace MWC_Localization_Core
         /// Use for dynamically created TextMeshes that appear after the initial scan.
         /// </summary>
         LateTranslateOnce,
+
+        /// <summary>
+        /// Apply the localized font once when the TextMesh becomes available, then stop monitoring.
+        /// Use for TextMeshes whose text is already translated upstream at the data source
+        /// (e.g. TeletextHandler / ArrayListProxyHandler / FsmTextHook mutate the backing data),
+        /// so no translation is needed - only the font swap.
+        /// </summary>
+        LateApplyFontOnce,
     }
 
     /// <summary>

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -180,15 +180,18 @@ namespace MWC_Localization_Core
             foreach (string parentPath in pathRules.Keys)
             {
                 MonitoringStrategy strategy = pathRules[parentPath];
-                if (strategy == MonitoringStrategy.LateTranslateOnce ||
-                    strategy == MonitoringStrategy.LateApplyFontOnce ||
-                    strategy == MonitoringStrategy.OnVisibilityChange ||
-                    strategy == MonitoringStrategy.Persistent)
+                int registered = Register(parentPath, strategy);
+
+                // Only queue for late retry if the initial Register couldn't find the parent yet
+                // (registered == 0). Persistent still stays queued so rebuilt children get picked up.
+                bool needsLateQueue = strategy == MonitoringStrategy.LateTranslateOnce ||
+                                      strategy == MonitoringStrategy.LateApplyFontOnce ||
+                                      strategy == MonitoringStrategy.OnVisibilityChange ||
+                                      strategy == MonitoringStrategy.Persistent;
+                if (needsLateQueue && (registered == 0 || strategy == MonitoringStrategy.Persistent))
                 {
                     monitoredPaths.Add(parentPath);
                 }
-
-                Register(parentPath, strategy);
             }
         }
 

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -131,7 +131,11 @@ namespace MWC_Localization_Core
             // Teletext/FSM displays are primarily translated at array/FSM source level.
             // Use one-shot late registration to avoid rescanning large TV trees continuously.
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/PAGES", MonitoringStrategy.LateTranslateOnce);
-            AddPathRule("Systems/TV/TVGraphics/CHAT/Generated", MonitoringStrategy.LateTranslateOnce);
+            // CHAT/Generated/Lines is already translated upstream by TeletextHandler via the
+            // Systems/TV/ChatMessages array, so the TextMesh text never matches a dictionary
+            // key on this end. Apply the font once and stop monitoring - no translation pass
+            // would ever succeed here.
+            AddPathRule("Systems/TV/TVGraphics/CHAT/Generated", MonitoringStrategy.LateApplyFontOnce);
 
             // Magazine / Sheets - on visibility change
             AddPathRule("Sheets/UnemployPaper", MonitoringStrategy.OnVisibilityChange);
@@ -161,6 +165,7 @@ namespace MWC_Localization_Core
             {
                 MonitoringStrategy strategy = pathRules[parentPath];
                 if (strategy == MonitoringStrategy.LateTranslateOnce ||
+                    strategy == MonitoringStrategy.LateApplyFontOnce ||
                     strategy == MonitoringStrategy.OnVisibilityChange ||
                     strategy == MonitoringStrategy.Persistent)
                 {
@@ -215,19 +220,38 @@ namespace MWC_Localization_Core
 
             // Get all TextMesh components under this parent
             TextMesh[] textMeshes = parent.GetComponentsInChildren<TextMesh>(true);
+
+            // Font-only fast path: these TextMeshes are translated upstream at the data
+            // source, so we only need to swap the font once and then forget about them.
+            // No per-instance tracking or follow-up monitoring is needed - the translator's
+            // appliedFontCache already prevents redundant re-application.
+            if (finalStrategy == MonitoringStrategy.LateApplyFontOnce)
+            {
+                foreach (var textMesh in textMeshes)
+                {
+                    if (textMesh == null)
+                        continue;
+
+                    string textMeshPath = MLCUtils.GetGameObjectPath(textMesh.gameObject);
+                    translator.ApplyFontOnly(textMesh, textMeshPath);
+                    registeredCount++;
+                }
+                return registeredCount;
+            }
+
             foreach (var textMesh in textMeshes)
             {
                 if (textMesh == null)
                     continue;
 
                 int instanceID = textMesh.GetInstanceID();
-                
+
                 // Skip if this specific instance is already registered
                 if (instanceEntries.ContainsKey(instanceID))
                     continue;
 
                 string textMeshPath = MLCUtils.GetGameObjectPath(textMesh.gameObject);
-                
+
                 // Translate first to reduce visible unlocalized text
                 bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath, null);
 

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -156,6 +156,22 @@ namespace MWC_Localization_Core
             pathRules[pathPattern] = strategy;
         }
 
+        // A parent scan (e.g. FastPolling on "CHAT/Day") must not absorb TextMeshes that have
+        // their own more-specific rule (e.g. LateApplyFontOnce on "CHAT/Day/Time"), or the
+        // one-shot rule gets silently demoted into continuous polling.
+        private bool HasMoreSpecificRule(string textMeshPath, string parentPath)
+        {
+            int parentLen = parentPath.Length;
+            foreach (var rule in pathRules.Keys)
+            {
+                if (rule.Length <= parentLen)
+                    continue;
+                if (rule == textMeshPath || textMeshPath.StartsWith(rule + "/"))
+                    return true;
+            }
+            return false;
+        }
+
         /// <summary>
         /// Register all TextMeshes under defined path rules
         /// </summary>
@@ -233,6 +249,8 @@ namespace MWC_Localization_Core
                         continue;
 
                     string textMeshPath = MLCUtils.GetGameObjectPath(textMesh.gameObject);
+                    if (HasMoreSpecificRule(textMeshPath, parentPath))
+                        continue;
                     translator.ApplyFontOnly(textMesh, textMeshPath);
                     registeredCount++;
                 }
@@ -251,6 +269,11 @@ namespace MWC_Localization_Core
                     continue;
 
                 string textMeshPath = MLCUtils.GetGameObjectPath(textMesh.gameObject);
+
+                // A more-specific path rule (e.g. child Late/OnVisibility rule) must handle this
+                // TextMesh instead of it being captured by this parent scan.
+                if (HasMoreSpecificRule(textMeshPath, parentPath))
+                    continue;
 
                 // Translate first to reduce visible unlocalized text
                 bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath, null);

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -131,11 +131,11 @@ namespace MWC_Localization_Core
             // Teletext/FSM displays are primarily translated at array/FSM source level.
             // Use one-shot late registration to avoid rescanning large TV trees continuously.
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/PAGES", MonitoringStrategy.LateTranslateOnce);
-            // CHAT/Generated/Lines is already translated upstream by TeletextHandler via the
-            // Systems/TV/ChatMessages array, so the TextMesh text never matches a dictionary
-            // key on this end. Apply the font once and stop monitoring - no translation pass
-            // would ever succeed here.
+            // CHAT/Generated/Lines is already translated upstream by TeletextHandler, 
+            // so the TextMesh text never matches a dictionary key on this end. 
+            // Apply the font once and stop monitoring - no translation pass would ever succeed here.
             AddPathRule("Systems/TV/TVGraphics/CHAT/Generated", MonitoringStrategy.LateApplyFontOnce);
+            AddPathRule("Systems/TV/TVGraphics/CHAT/Day/Time", MonitoringStrategy.LateApplyFontOnce);
 
             // Magazine / Sheets - on visibility change
             AddPathRule("Sheets/UnemployPaper", MonitoringStrategy.OnVisibilityChange);

--- a/dist/Assets/MWC_Localization_Core/translate.txt
+++ b/dist/Assets/MWC_Localization_Core/translate.txt
@@ -632,6 +632,7 @@ Pe: = 금:
 La: = 토:
 Su: = 일:
 se \= selkeää pi \= pilvistä Ls \= lumisadetta = 맑음 \= 맑은 날씨\n흐림 \= 구름 많음\n눈 \= 눈
+KLO  = 현재 시간 
 
 //// Computer POS
 Copying... 0% = 복사 중... 0%


### PR DESCRIPTION
## Summary

Fixes the custom localized font not being applied to chat-TV TextMeshes under `Systems/TV/TVGraphics/CHAT/Generated/Lines`.

### Root cause

`TeletextHandler.MonitorAndTranslateArrays` translates the `Systems/TV/ChatMessages` ArrayList contents *at the data source*, so by the time `UnifiedTextMeshMonitor` inspects the downstream TextMeshes the text is already localized. That broke the existing `LateTranslateOnce` plumbing in two ways:

- `TextMeshTranslator.ApplyTranslation` looks up the current text in the translation dictionary — the already-localized text never matches a source key, so it returns `false`.
- `ApplyCustomFont` is only called *after* a successful translation inside `ApplyTranslation`, so a `false` return means the font swap is skipped entirely.
- `WasTranslated` stays `false`, so the entry is never removed from `strategyGroups[LateTranslateOnce]` and the monitor silently re-attempts the same doomed translation on every slow-poll tick.

### Fix

Introduce a new `MonitoringStrategy.LateApplyFontOnce`: a one-shot pass that calls `translator.ApplyFontOnly` on every TextMesh under the registered parent path and then drops the path from the monitor. Switch `Systems/TV/TVGraphics/CHAT/Generated` to it.

Implementation notes:
- `Register` branches early for `LateApplyFontOnce` and does **not** insert TextMeshes into `instanceEntries` / `strategyGroups` — there is nothing further to poll. The translator's existing `appliedFontCache` prevents redundant font work if the path is (re)scanned.
- `RegisterAllPathRuleElements` adds the new strategy to `monitoredPaths` alongside `LateTranslateOnce` so `MonitorLateRegister` keeps retrying until the lazy-loaded TextMeshes actually exist, then removes the path.

This is the first of three planned PRs for the chat-font work:
1. **This PR** — minimal fix via new strategy.
2. Follow-up: migrate `ArrayListProxyHandler.ApplyFontsToArrayElements` and `MWC_Localization_Core.ApplyForcedFontPass` onto the new strategy so upstream-translation handlers co-own their font-path registration.
3. Follow-up: co-locate FsmTextHook font paths the same way; delete `ForcedFontPathPrefixes` from the main mod file.

## Test plan
- [ ] In-game: open a chat TV, verify `Lines` TextMeshes render with the localized font (not the original English atlas)
- [ ] Verify existing `LateTranslateOnce` behavior for `Systems/TV/Teletext/VKTekstiTV/PAGES` is unaffected (no double-font application, no missing translations)
- [ ] F8 reload: verify chat-TV font is re-applied after `textMeshMonitor.Clear()` + `ClearRuntimeCaches()`
- [ ] No CPU regression on slow-poll tick (previously the CHAT/Generated entries were re-checked every second; they now drop out after first successful scan)

https://claude.ai/code/session_013cG1H4EUg9CasK5MXWCaHs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a font-only monitoring mode that applies fonts once to late-loaded, already-localized text elements.

* **Performance**
  * Fast-path applies fonts without full translation or per-instance tracking, reducing runtime overhead and improving responsiveness.

* **Bug Fixes**
  * Enhanced rule specificity so one-shot font applications favor more-specific rules over broader parent rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->