### PR TITLE
fix: preserve original material color when applying custom fonts

### DIFF
--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -146,18 +146,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Some TV paths rely on runtime material/shader properties for tint/visibility effects.
-        /// </summary>
-        private bool IsRuntimeSensitiveTvPath(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-                return false;
-
-            return path.Contains("Systems/TV/TVGraphics/") ||
-                   path.Contains("Systems/TV/Teletext/VKTekstiTV/");
-        }
-
-        /// <summary>
         /// Handle complex text patterns (magazine text, cashier price line)
         /// Now uses unified pattern matcher for all pattern-based translations
         /// </summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -122,33 +122,22 @@ namespace MWC_Localization_Core
                 MeshRenderer renderer = textMesh.GetComponent<MeshRenderer>();
                 if (renderer != null && customFont.material != null)
                 {
-                    if (IsRuntimeSensitiveTvPath(path))
-                    {
-                        Texture targetMainTexture = customFont.material.mainTexture;
-                        int rendererInstanceID = renderer.GetInstanceID();
-                        bool needsTextureApply = !appliedRuntimeTextureCache.TryGetValue(rendererInstanceID, out Texture cachedTexture)
-                            || cachedTexture != targetMainTexture;
+                    Texture targetMainTexture = customFont.material.mainTexture;
+                    int rendererInstanceID = renderer.GetInstanceID();
+                    bool needsTextureApply = !appliedRuntimeTextureCache.TryGetValue(rendererInstanceID, out Texture cachedTexture)
+                        || cachedTexture != targetMainTexture;
 
-                        if (needsTextureApply && targetMainTexture != null)
-                        {
-                            // Keep the runtime material/shader setup intact and swap only the atlas texture.
-                            Material runtimeMaterial = renderer.material;
-                            if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
-                            {
-                                runtimeMaterial.mainTexture = targetMainTexture;
-                            }
-
-                            appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
-                        }
-                    }
-                    else
+                    if (needsTextureApply && targetMainTexture != null)
                     {
-                        // Do not mutate shared material textures in-place.
-                        // Rebinding the renderer material avoids corrupting other font atlases.
-                        if (renderer.sharedMaterial != customFont.material)
+                        // Always preserve original material properties (colors, tints, etc.) by swapping only the atlas texture.
+                        // This works for both TV and non-TV paths and preserves custom colors like yellow text.
+                        Material runtimeMaterial = renderer.material;
+                        if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
                         {
-                            renderer.sharedMaterial = customFont.material;
+                            runtimeMaterial.mainTexture = targetMainTexture;
                         }
+
+                        appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
                     }
                 }
 


### PR DESCRIPTION
Problem:
- Yellow and other custom colors were lost when applying custom fonts
- Material replacement (renderer.sharedMaterial = customFont.material) discarded original material properties including color tints

Solution:
- Always use texture-only swap (renderer.material.mainTexture) instead of full material replacement
- This preserves original material colors, tints, and properties while applying the new font atlas

Impact:
- Text colors (like yellow) are now preserved when custom fonts are applied
- Applies consistently to all paths (TV and non-TV)
- Removes conditional logic that was only preserving colors for TV paths

Changes:
- Unified material application strategy to swap only texture instead of replacing entire material
- Updated method to work for all TextMesh objects regardless of path

Bug fix https://github.com/potatosalad775/MWC_Localization_Core/issues/67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified font texture assignment for more consistent runtime font rendering, reducing unnecessary material reassignments and improving stability and performance of text visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->