### PR TITLE
Fix: RallyResults sheet translation on fast open

### DIFF
--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -142,8 +142,6 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/ServiceBrochure", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/ServicePayment", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/TrafficTicket", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyResults", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("COMPUTER/SYSTEM/TELEBBS/CONLINE/CommandLine", MonitoringStrategy.OnVisibilityChange);
 
             // Magazine / Sheets - persistent monitoring due to dynamic content changes and rebuilds
@@ -151,6 +149,8 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyResults", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.Persistent);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)


### PR DESCRIPTION
- Change Sheets/RallyResults from OnVisibilityChange to Persistent monitoring
- Ensures immediate translation even when sheet is already visible on registration
- Prevents need to close and reopen sheet for text to appear translated

I noticed a bug when opening the Rally Results and Registration Sheets; sometimes the text wouldn't translate, requiring me to close and reopen the pamphlet for translation. To mitigate this, I changed the rule to Persistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced monitoring for text display in Rally Results and Rally Registration sections for more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->