### PR TITLE
refactor: remove dead code and optimize scene translation pipeline

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -1,10 +1,8 @@
 // Generic handler for translating PlayMakerArrayListProxy data
 // Supports any GameObject with array-based content (HUD, menus, etc.)
 
-using MSCLoader;
 using UnityEngine;
 using System.Collections.Generic;
-using System.Text;
 using System.Collections;
 
 namespace MWC_Localization_Core

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -307,8 +307,8 @@ namespace MWC_Localization_Core
 
         private bool TryApplyMainMenuTranslations()
         {
-            GameObject folkObj = GameObject.Find("Radio/Folk");
-            GameObject cdObj = GameObject.Find("Radio/CD");
+            GameObject folkObj = MLCUtils.FindGameObjectCached("Radio/Folk");
+            GameObject cdObj = MLCUtils.FindGameObjectCached("Radio/CD");
 
             if (folkObj == null || cdObj == null)
                 return false;

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -1,5 +1,3 @@
-using MSCLoader;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -1,6 +1,4 @@
-using MSCLoader;
 using UnityEngine;
-using System.Collections.Generic;
 
 namespace MWC_Localization_Core
 {

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -1,6 +1,5 @@
 // Configuration file loader
 
-using MSCLoader;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -145,25 +145,7 @@ namespace MWC_Localization_Core
             TranslateScene();
             sceneManager.MarkSceneTranslated("GAME");
             InitializeFsmTextHook();
-            
-            // Reset handlers
-            teletextHandler.Reset();
-            arrayListHandler.Reset();
-            hashTableHandler.Reset();
-
-            // Translate static arrays immediately
-            int arrayTranslated = arrayListHandler.TranslateAllArrays();
-            if (arrayTranslated > 0)
-            {
-                CoreConsole.Print($"[{Name}] Translated {arrayTranslated} array items");
-                arrayListHandler.ApplyFontsToArrayElements();
-            }
-
-            int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
-            if (hashTableTranslated > 0)
-            {
-                CoreConsole.Print($"[{Name}] Translated {hashTableTranslated} hash table items");
-            }
+            InitializeGameDataSources("");
             
             // Create MonoBehaviour for LateUpdate monitoring
             // ALL continuous monitoring logic runs in LateUpdate to ensure correct timing
@@ -252,26 +234,27 @@ namespace MWC_Localization_Core
                 TranslateScene();
                 sceneManager.MarkSceneTranslated("GAME");
                 InitializeFsmTextHook();
-                
-                // Reset teletext handler and retry tracking for new scene
-                teletextHandler.Reset();
-                arrayListHandler.Reset();
-                hashTableHandler.Reset();
-                
-                // Translate static arrays immediately (HUD, menus, etc.)
-                int arrayTranslated = arrayListHandler.TranslateAllArrays();
-                if (arrayTranslated > 0)
-                {
-                    CoreConsole.Print($"[{Name}] [Arrays] Initial translation: {arrayTranslated} items");
-                    // Apply Korean fonts to TextMesh components using array data
-                    arrayListHandler.ApplyFontsToArrayElements();
-                }
+                InitializeGameDataSources("Initial ");
+            }
+        }
 
-                int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
-                if (hashTableTranslated > 0)
-                {
-                    CoreConsole.Print($"[{Name}] [HashTables] Initial translation: {hashTableTranslated} items");
-                }
+        private void InitializeGameDataSources(string logPrefix)
+        {
+            teletextHandler.Reset();
+            arrayListHandler.Reset();
+            hashTableHandler.Reset();
+
+            int arrayTranslated = arrayListHandler.TranslateAllArrays();
+            if (arrayTranslated > 0)
+            {
+                CoreConsole.Print($"[{Name}] {logPrefix}translated {arrayTranslated} array items");
+                arrayListHandler.ApplyFontsToArrayElements();
+            }
+
+            int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
+            if (hashTableTranslated > 0)
+            {
+                CoreConsole.Print($"[{Name}] {logPrefix}translated {hashTableTranslated} hash table items");
             }
         }
 
@@ -553,52 +536,33 @@ namespace MWC_Localization_Core
             // Find all TextMesh components in the scene
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
             int translatedCount = 0;
+            int forcedFontAppliedCount = 0;
 
             foreach (TextMesh tm in allTextMeshes)
             {
-                if (tm == null || string.IsNullOrEmpty(tm.text))
+                if (tm == null)
                     continue;
 
                 // Get GameObject path
                 string path = MLCUtils.GetGameObjectPath(tm.gameObject);
 
                 // Translate and apply font
-                bool translated = translator.TranslateAndApplyFont(tm, path, null);
-                if (translated)
+                if (!string.IsNullOrEmpty(tm.text))
                 {
-                    translatedCount++;
+                    bool translated = translator.TranslateAndApplyFont(tm, path, null);
+                    if (translated)
+                    {
+                        translatedCount++;
+                    }
+                }
+
+                if (PathStartsWithAny(path, ForcedFontPathPrefixes) && translator.ApplyFontOnly(tm, path))
+                {
+                    forcedFontAppliedCount++;
                 }
             }
-
-            int forcedFontAppliedCount = ApplyForcedFontPass(allTextMeshes);
 
             CoreConsole.Print($"[{Name}] Scene translation complete: {translatedCount}/{allTextMeshes.Length} TextMesh objects translated, forced font pass: {forcedFontAppliedCount}");
-        }
-
-        private int ApplyForcedFontPass(TextMesh[] allTextMeshes)
-        {
-            if (translator == null || allTextMeshes == null || allTextMeshes.Length == 0)
-                return 0;
-
-            int appliedCount = 0;
-
-            for (int i = 0; i < allTextMeshes.Length; i++)
-            {
-                TextMesh tm = allTextMeshes[i];
-                if (tm == null)
-                    continue;
-
-                string path = MLCUtils.GetGameObjectPath(tm.gameObject);
-                if (!PathStartsWithAny(path, ForcedFontPathPrefixes))
-                    continue;
-
-                if (translator.ApplyFontOnly(tm, path))
-                {
-                    appliedCount++;
-                }
-            }
-
-            return appliedCount;
         }
 
         private bool PathStartsWithAny(string path, string[] prefixes)

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -549,7 +549,7 @@ namespace MWC_Localization_Core
                 // Translate and apply font
                 if (!string.IsNullOrEmpty(tm.text))
                 {
-                    bool translated = translator.TranslateAndApplyFont(tm, path, null);
+                    bool translated = translator.TranslateAndApplyFont(tm, path);
                     if (translated)
                     {
                         translatedCount++;

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -1,9 +1,6 @@
 // 'Classified Magazine' Text Handler
 
-using MSCLoader;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using UnityEngine;
 
 namespace MWC_Localization_Core

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -50,11 +50,6 @@ namespace MWC_Localization_Core
     public enum TranslationMode
     {
         /// <summary>
-        /// Simple dictionary lookup for exact text keys.
-        /// </summary>
-        SimpleLookup,
-
-        /// <summary>
         /// Pattern matching with {0}, {1}, and similar placeholders.
         /// </summary>
         FsmPattern,

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -6,12 +6,6 @@ namespace MWC_Localization_Core
     public enum MonitoringStrategy
     {
         /// <summary>
-        /// Translate once during the initial scene scan, then stop monitoring.
-        /// Use for static UI elements that never change.
-        /// </summary>
-        TranslateOnce,
-
-        /// <summary>
         /// Monitor every frame without throttling.
         /// Use for interaction prompts, subtitles, and other critical real-time UI.
         /// </summary>
@@ -22,12 +16,6 @@ namespace MWC_Localization_Core
         /// Use for active HUD elements that update frequently.
         /// </summary>
         FastPolling,
-
-        /// <summary>
-        /// Monitor at a slow polling interval for less critical content.
-        /// Use for teletext, FSM-generated content, and weather displays.
-        /// </summary>
-        SlowPolling,
 
         /// <summary>
         /// Keep checking even after translation for content that is frequently rebuilt.
@@ -70,16 +58,6 @@ namespace MWC_Localization_Core
         /// Pattern matching with {0}, {1}, and similar placeholders.
         /// </summary>
         FsmPattern,
-
-        /// <summary>
-        /// Regular expression extraction and replacement.
-        /// </summary>
-        RegexExtract,
-
-        /// <summary>
-        /// Split by comma and translate each item independently.
-        /// </summary>
-        CommaSeparated,
 
         /// <summary>
         /// Use a custom handler for more complex translation logic.

--- a/PatternMatcher.cs
+++ b/PatternMatcher.cs
@@ -1,6 +1,5 @@
 // Pattern matching system for Translation Strings
 
-using MSCLoader;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -39,29 +38,6 @@ namespace MWC_Localization_Core
         /// </summary>
         private void InitializeBuiltInPatterns()
         {
-            // Magazine price/phone pattern (custom handler)
-            var magazinePricePattern = new TranslationPattern(
-                "MagazinePrice",
-                TranslationMode.CustomHandler,
-                "h.{price},- puh.{phone}",
-                "{price} MK, {PHONE} - {phone}"
-            );
-            magazinePricePattern.PathMatcher = path => path.Contains("YellowPagesMagazine");
-            magazinePricePattern.TextMatcher = text => text.StartsWith("h.") && text.Contains(",- puh.");
-            magazinePricePattern.CustomHandler = TranslateMagazinePriceLine;
-            AddPatternInternal(magazinePricePattern, true);
-
-            // Magazine comma-separated words
-            var magazineWordsPattern = new TranslationPattern(
-                "MagazineWords",
-                TranslationMode.CommaSeparated,
-                "",
-                ""
-            );
-            magazineWordsPattern.PathMatcher = path => path.Contains("YellowPagesMagazine");
-            magazineWordsPattern.TextMatcher = text => text.Split(',').Length == 3;
-            AddPatternInternal(magazineWordsPattern, true);
-
             // Multi-line Computer command text handler
             var pcScreenPattern = new TranslationPattern(
                 "PCMultiLine",
@@ -89,7 +65,6 @@ namespace MWC_Localization_Core
             try
             {
                 string[] lines = File.ReadAllLines(filePath, Encoding.UTF8);
-                string currentSection = null;
                 int loadedCount = 0;
 
                 foreach (string line in lines)
@@ -103,7 +78,6 @@ namespace MWC_Localization_Core
                     // Check for section header
                     if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
                     {
-                        currentSection = trimmed.Substring(1, trimmed.Length - 2);
                         continue;
                     }
 
@@ -176,8 +150,8 @@ namespace MWC_Localization_Core
             string upperText = null;
             foreach (var pattern in patterns)
             {
-                // CustomHandler patterns work on original text; FSM/Regex need uppercase
-                bool needsUpper = pattern.Mode != TranslationMode.CustomHandler && pattern.Mode != TranslationMode.CommaSeparated;
+                // CustomHandler patterns work on original text; FSM patterns need uppercase
+                bool needsUpper = pattern.Mode != TranslationMode.CustomHandler;
                 string inputText;
                 if (needsUpper)
                 {
@@ -198,23 +172,6 @@ namespace MWC_Localization_Core
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Add a pattern programmatically
-        /// </summary>
-        public void AddPattern(TranslationPattern pattern)
-        {
-            AddPatternInternal(pattern, false);
-        }
-
-        /// <summary>
-        /// Clear all patterns
-        /// </summary>
-        public void ClearPatterns()
-        {
-            patterns.Clear();
-            patternSignatures.Clear();
         }
 
         private bool AddPatternInternal(TranslationPattern pattern, bool appendToEnd)
@@ -244,42 +201,6 @@ namespace MWC_Localization_Core
             string original = pattern.OriginalPattern ?? string.Empty;
             string translated = pattern.TranslatedTemplate ?? string.Empty;
             return ((int)pattern.Mode).ToString() + "|" + original + "|" + translated;
-        }
-
-        /// <summary>
-        /// Custom handler for magazine price/phone lines
-        /// Format: "h.149,- puh.123456" -> "149 MK, PHONE - 123456"
-        /// </summary>
-        private TranslationPattern.CustomHandlerResult TranslateMagazinePriceLine(string text, string path, Dictionary<string, string> translations)
-        {
-            try
-            {
-                // Remove "h." prefix and split by ",- puh."
-                if (!text.StartsWith("h."))
-                    return new TranslationPattern.CustomHandlerResult(false, null);
-
-                string withoutPrefix = text.Substring(2);
-                string[] parts = withoutPrefix.Split(new string[] { ",- puh." }, System.StringSplitOptions.None);
-
-                if (parts.Length == 2)
-                {
-                    string pricePart = parts[0].Trim();
-                    string phonePart = parts[1].Trim();
-
-                    // Get phone label from translations
-                    string phoneLabel = translations.TryGetValue("PHONE", out string translation)
-                        ? translation
-                        : "PHONE";
-
-                    return new TranslationPattern.CustomHandlerResult(true, $"{pricePart} MK, {phoneLabel} - {phonePart}");
-                }
-            }
-            catch (System.Exception ex)
-            {
-                CoreConsole.Warning($"Failed to parse magazine price/phone line: {text} - {ex.Message}");
-            }
-
-            return new TranslationPattern.CustomHandlerResult(false, null);
         }
 
         /// <summary>

--- a/PatternMatcher.cs
+++ b/PatternMatcher.cs
@@ -225,7 +225,7 @@ namespace MWC_Localization_Core
                     }
 
                     // Try to translate this line
-                    string key = trimmed.ToUpperInvariant();
+                    string key = MLCUtils.FormatUpperKey(trimmed);
                     if (translations.TryGetValue(key, out string translation))
                     {
                         translatedLines.Add(translation);

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -12,8 +12,6 @@ namespace MWC_Localization_Core
         
         // Current scene tracking
         private string currentScene = "";
-        private string previousScene = "";
-
         public SceneTranslationManager()
         {
         }
@@ -66,7 +64,7 @@ namespace MWC_Localization_Core
 
             if (currentScene != newScene)
             {
-                previousScene = currentScene;
+                string previousScene = currentScene;
                 currentScene = newScene;
                 
                 HandleSceneChange(previousScene, currentScene);

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -1,5 +1,3 @@
-using MSCLoader;
-
 namespace MWC_Localization_Core
 {
     /// <summary>

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,7 +207,7 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
-                    string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
+                    string translationKey = MLCUtils.FormatUpperKey(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,7 +207,7 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
-                    string translationKey = TranslationFileParser.NormalizeCategoryKey(normalizedOriginal);
+                    string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,7 +207,7 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
-                    string translationKey = MLCUtils.FormatUpperKey(normalizedOriginal);
+                    string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,12 +207,13 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
+                    string translationKey = MLCUtils.FormatUpperKey(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;
                     
                     // Try exact key match first
-                    if (translations.TryGetValue(normalizedOriginal, out string translation))
+                    if (translations.TryGetValue(translationKey, out string translation))
                     {
                         if (original != translation)
                         {

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,7 +207,7 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
-                    string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
+                    string translationKey = TranslationFileParser.NormalizeCategoryKey(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -214,14 +214,17 @@ namespace MWC_Localization_Core
                     // Try exact key match first
                     if (translations.TryGetValue(normalizedOriginal, out string translation))
                     {
-                        arrayList[i] = translation;
-                        translatedCount++;
+                        if (original != translation)
+                        {
+                            arrayList[i] = translation;
+                            translatedCount++;
+                        }
                     }
                     // Fallback: Use index-based translation if available
                     else if (hasIndexFallback && nonEmptySourceIndex < indexBasedTranslations[categoryName].Count)
                     {
                         string indexTranslation = indexBasedTranslations[categoryName][nonEmptySourceIndex];
-                        if (!string.IsNullOrEmpty(indexTranslation))
+                        if (!string.IsNullOrEmpty(indexTranslation) && original != indexTranslation)
                         {
                             arrayList[i] = indexTranslation;
                             translatedCount++;

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -61,16 +61,11 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Translate TextMesh and apply custom font + position adjustments
         /// </summary>
-        /// <param name="translatedTextMeshes">HashSet tracking which TextMesh objects have been translated</param>
         /// <returns>True if text was translated or already localized</returns>
-        public bool TranslateAndApplyFont(TextMesh textMesh, string path, HashSet<TextMesh> translatedTextMeshes)
+        public bool TranslateAndApplyFont(TextMesh textMesh, string path)
         {
             if (textMesh == null || string.IsNullOrEmpty(textMesh.text))
                 return false;
-
-            // Skip if already translated (language-agnostic check)
-            if (translatedTextMeshes != null && translatedTextMeshes.Contains(textMesh))
-                return true;
 
             // Skip excluded paths
             foreach(string excluded in ExcludedPath)
@@ -79,12 +74,17 @@ namespace MWC_Localization_Core
                     return false;
             }
 
-            // Try complex text handling first (e.g., magazine text, cashier price)
-            if (HandleComplexTextMesh(textMesh, path))
+            if (magazineHandler.IsMagazineText(path))
+            {
+                ApplyCustomFont(textMesh, path);
+                return magazineHandler.HandleMagazineText(textMesh);
+            }
+
+            // Use standard translation before pattern matching; dictionary lookup is cheaper.
+            if (ApplyTranslation(textMesh, path))
                 return true;
 
-            // Use standard translation
-            if (ApplyTranslation(textMesh, path))
+            if (ApplyPatternTranslation(textMesh, path))
                 return true;
 
             return false;
@@ -151,32 +151,19 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Handle complex text patterns (magazine text, cashier price line)
-        /// Now uses unified pattern matcher for all pattern-based translations
+        /// Handle pattern-based text translations.
         /// </summary>
-        bool HandleComplexTextMesh(TextMesh textMesh, string path)
+        bool ApplyPatternTranslation(TextMesh textMesh, string path)
         {
-            // Check magazine text FIRST - it requires special handling (comma-separated words, price/phone format)
-            if (magazineHandler.IsMagazineText(path))
-            {
-                // Apply custom font first
-                ApplyCustomFont(textMesh, path);
-                // Apply Translation
-                return magazineHandler.HandleMagazineText(textMesh);
-            }
-            
-            // Try pattern matching for other complex texts (FSM, Price patterns)
             string patternResult = patternMatcher.TryTranslateWithPattern(textMesh.text, path);
             if (patternResult != null)
             {
-                // Apply custom font first
                 ApplyCustomFont(textMesh, path);
-                // Apply Translation
                 textMesh.text = patternResult;
                 return true;
             }
 
-            return false; // Not handled, use standard translation
+            return false;
         }
 
         /// <summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -134,15 +134,21 @@ namespace MWC_Localization_Core
                         {
                             // Preserve per-renderer material properties while avoiding repeated renderer.material instantiation.
                             runtimeMaterial = renderer.material;
-                            runtimeMaterialCache[rendererInstanceID] = runtimeMaterial;
+                            if (runtimeMaterial != null)
+                            {
+                                runtimeMaterialCache[rendererInstanceID] = runtimeMaterial;
+                            }
                         }
 
-                        if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
+                        if (runtimeMaterial != null)
                         {
-                            runtimeMaterial.mainTexture = targetMainTexture;
-                        }
+                            if (runtimeMaterial.mainTexture != targetMainTexture)
+                            {
+                                runtimeMaterial.mainTexture = targetMainTexture;
+                            }
 
-                        appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
+                            appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
+                        }
                     }
                 }
 

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -77,7 +77,8 @@ namespace MWC_Localization_Core
             if (magazineHandler.IsMagazineText(path))
             {
                 ApplyCustomFont(textMesh, path);
-                return magazineHandler.HandleMagazineText(textMesh);
+                magazineHandler.HandleMagazineText(textMesh);
+                return true;
             }
 
             // Use standard translation before pattern matching; dictionary lookup is cheaper.

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -1,4 +1,3 @@
-using MSCLoader;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -17,6 +16,7 @@ namespace MWC_Localization_Core
         private LocalizationConfig config;
         private Dictionary<int, string> appliedFontCache = new Dictionary<int, string>();
         private Dictionary<int, Texture> appliedRuntimeTextureCache = new Dictionary<int, Texture>();
+        private Dictionary<int, Material> runtimeMaterialCache = new Dictionary<int, Material>();
         private Dictionary<string, Font> fontNameToFont;  // Reverse lookup: font.name -> Font
 
         private static readonly string[] ExcludedPath = new string[]
@@ -129,9 +129,14 @@ namespace MWC_Localization_Core
 
                     if (needsTextureApply && targetMainTexture != null)
                     {
-                        // Always preserve original material properties (colors, tints, etc.) by swapping only the atlas texture.
-                        // This works for both TV and non-TV paths and preserves custom colors like yellow text.
-                        Material runtimeMaterial = renderer.material;
+                        Material runtimeMaterial;
+                        if (!runtimeMaterialCache.TryGetValue(rendererInstanceID, out runtimeMaterial) || runtimeMaterial == null)
+                        {
+                            // Preserve per-renderer material properties while avoiding repeated renderer.material instantiation.
+                            runtimeMaterial = renderer.material;
+                            runtimeMaterialCache[rendererInstanceID] = runtimeMaterial;
+                        }
+
                         if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
                         {
                             runtimeMaterial.mainTexture = targetMainTexture;
@@ -204,45 +209,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Translate multiline text line-by-line.
-        /// Useful for dynamic displays that append lines over time.
-        /// </summary>
-        public bool TranslateMultilineByLines(TextMesh textMesh, string path)
-        {
-            if (textMesh == null || string.IsNullOrEmpty(textMesh.text))
-                return false;
-
-            string original = textMesh.text;
-            string[] lines = original.Split('\n');
-            bool changed = false;
-
-            for (int i = 0; i < lines.Length; i++)
-            {
-                string line = lines[i];
-                if (string.IsNullOrEmpty(line))
-                    continue;
-
-                string trimmedCr = line.Replace("\r", string.Empty);
-                string normalizedKey = MLCUtils.FormatUpperKey(trimmedCr);
-                if (string.IsNullOrEmpty(normalizedKey))
-                    continue;
-
-                if (translations.TryGetValue(normalizedKey, out string translatedLine) && trimmedCr != translatedLine)
-                {
-                    lines[i] = translatedLine;
-                    changed = true;
-                }
-            }
-
-            if (!changed)
-                return false;
-
-            ApplyCustomFont(textMesh, path);
-            textMesh.text = string.Join("\n", lines);
-            return true;
-        }
-
-        /// <summary>
         /// Get custom font for the given original font name
         /// </summary>
         Font GetCustomFont(string originalFontName)
@@ -295,6 +261,7 @@ namespace MWC_Localization_Core
         {
             appliedFontCache.Clear();
             appliedRuntimeTextureCache.Clear();
+            runtimeMaterialCache.Clear();
         }
     }
 }

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -213,10 +213,11 @@ namespace MWC_Localization_Core
                         // concatenation fragments do, and the lookup side (TranslateArrayListProxy)
                         // trims the game-provided original before dict lookup, so preserving
                         // trailing whitespace here would cause keys to silently miss.
-                        string key = NormalizeCategoryKey(line.Substring(0, equalsIndex));
+                        string key = line.Substring(0, equalsIndex).Trim();
                         string value = line.Substring(equalsIndex + 1).Trim();
 
                         // Unescape special characters
+                        key = UnescapeString(key);
                         value = UnescapeString(value);
 
                         if (!string.IsNullOrEmpty(key) && currentDict != null)
@@ -271,17 +272,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Normalize keys used by category-based translation files (e.g. teletext).
-        /// </summary>
-        public static string NormalizeCategoryKey(string input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return input;
-
-            return UnescapeString(input.Trim());
-        }
-
-        /// <summary>
         /// Helper method to save a multi-line entry
         /// </summary>
         private static void SaveEntry(Dictionary<string, string> dict, List<string> indexList, List<string> keyLines, List<string> valueLines, ref int count)
@@ -297,10 +287,11 @@ namespace MWC_Localization_Core
             // "=" on its own line). The lookup side (TranslateArrayListProxy) trims the
             // game-provided original before dict lookup, so keys must be trimmed here to
             // match; values get trimmed for consistency.
-            key = NormalizeCategoryKey(key);
+            key = key.Trim();
             value = value.Trim();
 
             // Unescape special characters in both key and value
+            key = UnescapeString(key);
             value = UnescapeString(value);
 
             if (!string.IsNullOrEmpty(key))

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -213,11 +213,10 @@ namespace MWC_Localization_Core
                         // concatenation fragments do, and the lookup side (TranslateArrayListProxy)
                         // trims the game-provided original before dict lookup, so preserving
                         // trailing whitespace here would cause keys to silently miss.
-                        string key = line.Substring(0, equalsIndex).Trim();
+                        string key = NormalizeCategoryKey(line.Substring(0, equalsIndex));
                         string value = line.Substring(equalsIndex + 1).Trim();
 
                         // Unescape special characters
-                        key = UnescapeString(key);
                         value = UnescapeString(value);
 
                         if (!string.IsNullOrEmpty(key) && currentDict != null)
@@ -272,6 +271,17 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Normalize keys used by category-based translation files (e.g. teletext).
+        /// </summary>
+        public static string NormalizeCategoryKey(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            return UnescapeString(input.Trim());
+        }
+
+        /// <summary>
         /// Helper method to save a multi-line entry
         /// </summary>
         private static void SaveEntry(Dictionary<string, string> dict, List<string> indexList, List<string> keyLines, List<string> valueLines, ref int count)
@@ -287,11 +297,10 @@ namespace MWC_Localization_Core
             // "=" on its own line). The lookup side (TranslateArrayListProxy) trims the
             // game-provided original before dict lookup, so keys must be trimmed here to
             // match; values get trimmed for consistency.
-            key = key.Trim();
+            key = NormalizeCategoryKey(key);
             value = value.Trim();
 
             // Unescape special characters in both key and value
-            key = UnescapeString(key);
             value = UnescapeString(value);
 
             if (!string.IsNullOrEmpty(key))

--- a/TranslationPattern.cs
+++ b/TranslationPattern.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using UnityEngine;
 
 namespace MWC_Localization_Core
 {
     /// <summary>
     /// Represents a translation pattern with extraction and formatting logic
-    /// Supports placeholders, regex, comma-separated values, and custom handlers
+    /// Supports placeholders and custom handlers
     /// </summary>
     public class TranslationPattern
     {
@@ -23,9 +21,6 @@ namespace MWC_Localization_Core
         // For FsmPattern mode
         private string[] originalParts;
         private string[] translationParts;
-        
-        // For RegexExtract mode
-        private Regex regexPattern;
         
         // For CustomHandler mode
         public Func<string, string, Dictionary<string, string>, CustomHandlerResult> CustomHandler { get; set; }
@@ -60,10 +55,6 @@ namespace MWC_Localization_Core
                 case TranslationMode.FsmPattern:
                 case TranslationMode.FsmPatternWithTranslation:
                     InitializeFsmPattern();
-                    break;
-                    
-                case TranslationMode.RegexExtract:
-                    InitializeRegexPattern();
                     break;
             }
         }
@@ -114,18 +105,6 @@ namespace MWC_Localization_Core
             return parts.ToArray();
         }
 
-        private void InitializeRegexPattern()
-        {
-            try
-            {
-                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError($"Failed to compile regex pattern '{OriginalPattern}': {ex.Message}");
-            }
-        }
-
         /// <summary>
         /// Check if this pattern matches the given text and path
         /// </summary>
@@ -145,13 +124,6 @@ namespace MWC_Localization_Core
                 case TranslationMode.FsmPattern:
                 case TranslationMode.FsmPatternWithTranslation:
                     return TryExtractFsmValues(text) != null;
-                    
-                case TranslationMode.RegexExtract:
-                    return regexPattern != null && regexPattern.IsMatch(text);
-                    
-                case TranslationMode.CommaSeparated:
-                    return text.Contains(",");
-                    
                 default:
                     return false;
             }
@@ -173,13 +145,6 @@ namespace MWC_Localization_Core
                     
                 case TranslationMode.FsmPatternWithTranslation:
                     return TranslateWithFsmPatternAndTranslateParams(text, translations);
-                    
-                case TranslationMode.RegexExtract:
-                    return TranslateWithRegex(text, translations);
-                    
-                case TranslationMode.CommaSeparated:
-                    return TranslateCommaSeparated(text, translations);
-                    
                 case TranslationMode.CustomHandler:
                     if (CustomHandler != null)
                     {
@@ -294,55 +259,6 @@ namespace MWC_Localization_Core
             }
             
             return values.ToArray();
-        }
-
-        private string TranslateWithRegex(string text, Dictionary<string, string> translations)
-        {
-            Match match = regexPattern.Match(text);
-            if (!match.Success)
-                return null;
-            
-            string result = TranslatedTemplate;
-            
-            // Replace {0}, {1}, {2} with captured groups
-            for (int i = 1; i < match.Groups.Count; i++)
-            {
-                result = result.Replace("{" + (i - 1) + "}", match.Groups[i].Value);
-            }
-            
-            // Replace {KEYNAME} with translations (e.g., {PRICETOTAL})
-            foreach (Match keyMatch in Regex.Matches(result, @"\{([A-Z]+)\}"))
-            {
-                string key = keyMatch.Groups[1].Value;
-                if (translations.TryGetValue(key, out string translation))
-                {
-                    result = result.Replace("{" + key + "}", translation);
-                }
-            }
-            
-            return result;
-        }
-
-        private string TranslateCommaSeparated(string text, Dictionary<string, string> translations)
-        {
-            string[] words = text.Split(',');
-            
-            for (int i = 0; i < words.Length; i++)
-            {
-                string word = words[i].Trim();
-                string key = MLCUtils.FormatUpperKey(word);
-                
-                if (translations.TryGetValue(key, out string translation))
-                {
-                    words[i] = translation;
-                }
-                else
-                {
-                    words[i] = word;
-                }
-            }
-            
-            return string.Join(", ", words);
         }
     }
 }

--- a/TranslationPattern.cs
+++ b/TranslationPattern.cs
@@ -9,7 +9,6 @@ namespace MWC_Localization_Core
     /// </summary>
     public class TranslationPattern
     {
-        public string Name { get; private set; }
         public TranslationMode Mode { get; private set; }
         public string OriginalPattern { get; private set; }
         public string TranslatedTemplate { get; private set; }
@@ -20,8 +19,6 @@ namespace MWC_Localization_Core
         
         // For FsmPattern mode
         private string[] originalParts;
-        private string[] translationParts;
-        
         // For CustomHandler mode
         public Func<string, string, Dictionary<string, string>, CustomHandlerResult> CustomHandler { get; set; }
         
@@ -40,7 +37,6 @@ namespace MWC_Localization_Core
 
         public TranslationPattern(string name, TranslationMode mode, string originalPattern, string translatedTemplate)
         {
-            Name = name;
             Mode = mode;
             OriginalPattern = originalPattern;
             TranslatedTemplate = translatedTemplate;
@@ -64,7 +60,6 @@ namespace MWC_Localization_Core
             // Split patterns by placeholders to get static parts
             // Example: "pakkasta {0} astetta" -> ["pakkasta ", " astetta"]
             originalParts = SplitPattern(OriginalPattern);
-            translationParts = SplitPattern(TranslatedTemplate);
         }
 
         private string[] SplitPattern(string pattern)
@@ -124,6 +119,10 @@ namespace MWC_Localization_Core
                 case TranslationMode.FsmPattern:
                 case TranslationMode.FsmPatternWithTranslation:
                     return TryExtractFsmValues(text) != null;
+
+                case TranslationMode.CustomHandler:
+                    return CustomHandler != null;
+
                 default:
                     return false;
             }

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -287,6 +287,12 @@ namespace MWC_Localization_Core
                     entry.UpdateLastText();
                 }
 
+                if (finalStrategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
+                {
+                    registeredCount++;
+                    continue;
+                }
+
                 // Register instance
                 instanceEntries[instanceID] = entry;
                 
@@ -362,6 +368,12 @@ namespace MWC_Localization_Core
 
                 // Check validity first to avoid NullReferenceException on destroyed objects
                 if (!entry.IsValid())
+                {
+                    removalBuffer.Add(instanceID);
+                    continue;
+                }
+
+                if (strategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
                 {
                     removalBuffer.Add(instanceID);
                     continue;

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -287,12 +287,6 @@ namespace MWC_Localization_Core
                     entry.UpdateLastText();
                 }
 
-                if (finalStrategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
-                {
-                    registeredCount++;
-                    continue;
-                }
-
                 // Register instance
                 instanceEntries[instanceID] = entry;
                 
@@ -368,12 +362,6 @@ namespace MWC_Localization_Core
 
                 // Check validity first to avoid NullReferenceException on destroyed objects
                 if (!entry.IsValid())
-                {
-                    removalBuffer.Add(instanceID);
-                    continue;
-                }
-
-                if (strategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
                 {
                     removalBuffer.Add(instanceID);
                     continue;

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -1,4 +1,3 @@
-using MSCLoader;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -73,7 +72,6 @@ namespace MWC_Localization_Core
         
         // Instance-based storage (supports multiple TextMeshes per path)
         private Dictionary<int, TextMeshEntry> instanceEntries;  // instanceID -> entry
-        private Dictionary<string, HashSet<int>> pathToInstances;  // path -> instanceIDs
         private Dictionary<MonitoringStrategy, HashSet<int>> strategyGroups;  // strategy -> instanceIDs
         private HashSet<string> monitoredPaths = new HashSet<string>();
         private List<int> removalBuffer = new List<int>(64);
@@ -84,7 +82,6 @@ namespace MWC_Localization_Core
             this.translator = translator;
             pathRules = new Dictionary<string, MonitoringStrategy>();
             instanceEntries = new Dictionary<int, TextMeshEntry>();
-            pathToInstances = new Dictionary<string, HashSet<int>>();
             strategyGroups = new Dictionary<MonitoringStrategy, HashSet<int>>();
 
             // Initialize strategy groups
@@ -142,8 +139,6 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/ServiceBrochure", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/ServicePayment", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/TrafficTicket", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyResults", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("COMPUTER/SYSTEM/TELEBBS/CONLINE/CommandLine", MonitoringStrategy.OnVisibilityChange);
 
             // Magazine / Sheets - persistent monitoring due to dynamic content changes and rebuilds
@@ -151,6 +146,8 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyResults", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.Persistent);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
@@ -293,15 +290,6 @@ namespace MWC_Localization_Core
                 // Register instance
                 instanceEntries[instanceID] = entry;
                 
-                // Index by path
-                HashSet<int> pathSet;
-                if (!pathToInstances.TryGetValue(textMeshPath, out pathSet))
-                {
-                    pathSet = new HashSet<int>();
-                    pathToInstances[textMeshPath] = pathSet;
-                }
-                pathSet.Add(instanceID);
-                
                 // Group by strategy
                 strategyGroups[finalStrategy].Add(instanceID);
 
@@ -322,15 +310,6 @@ namespace MWC_Localization_Core
             // Remove from strategy group
             strategyGroups[entry.Strategy].Remove(instanceID);
 
-            // Remove from path index
-            HashSet<int> pathSet;
-            if (pathToInstances.TryGetValue(entry.Path, out pathSet))
-            {
-                pathSet.Remove(instanceID);
-                if (pathSet.Count == 0)
-                    pathToInstances.Remove(entry.Path);
-            }
-            
             // Remove instance
             instanceEntries.Remove(instanceID);
         }
@@ -356,7 +335,6 @@ namespace MWC_Localization_Core
             slowPollingTimer += deltaTime;
             if (slowPollingTimer >= LocalizationConstants.SLOW_POLLING_INTERVAL)
             {
-                UpdateGroup(MonitoringStrategy.SlowPolling);
                 UpdateGroup(MonitoringStrategy.LateTranslateOnce);
                 MonitorLateRegister(); // Also check for late registrations
                 slowPollingTimer = 0f;
@@ -406,8 +384,8 @@ namespace MWC_Localization_Core
                         entry.WasTranslated = true;
                         entry.UpdateLastText();
 
-                        // Mark for removal if TranslateOnce
-                        if (strategy == MonitoringStrategy.TranslateOnce || strategy == MonitoringStrategy.LateTranslateOnce)
+                        // Late one-shot entries can stop monitoring after the first successful translation.
+                        if (strategy == MonitoringStrategy.LateTranslateOnce)
                         {
                             removalBuffer.Add(instanceID);
                         }
@@ -461,7 +439,6 @@ namespace MWC_Localization_Core
                 group.Clear();
             }
             instanceEntries.Clear();
-            pathToInstances.Clear();
             pathRules.Clear();
             monitoredPaths.Clear();
             fastPollingTimer = 0f;

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -278,7 +278,7 @@ namespace MWC_Localization_Core
                     continue;
 
                 // Translate first to reduce visible unlocalized text
-                bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath, null);
+                bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath);
 
                 TextMeshEntry entry = new TextMeshEntry(textMesh, textMeshPath, finalStrategy);
                 if (translated)
@@ -363,9 +363,7 @@ namespace MWC_Localization_Core
                 // Check validity first to avoid NullReferenceException on destroyed objects
                 if (!entry.IsValid())
                 {
-                    // Persistent strategy: Keep checking even if entry is not valid
-                    if (strategy != MonitoringStrategy.Persistent)
-                        removalBuffer.Add(instanceID);
+                    removalBuffer.Add(instanceID);
                     continue;
                 }
 
@@ -378,7 +376,7 @@ namespace MWC_Localization_Core
                 
                 if (textChanged || !entry.WasTranslated)
                 {
-                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
+                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
                     if (translated)
                     {
                         entry.WasTranslated = true;
@@ -403,6 +401,7 @@ namespace MWC_Localization_Core
         private void UpdateVisibilityChangeGroup()
         {
             var instanceIDs = strategyGroups[MonitoringStrategy.OnVisibilityChange];
+            removalBuffer.Clear();
 
             foreach (int instanceID in instanceIDs)
             {
@@ -411,7 +410,10 @@ namespace MWC_Localization_Core
                     continue;
 
                 if (!entry.IsValid())
+                {
+                    removalBuffer.Add(instanceID);
                     continue;
+                }
 
                 bool wasVisible = entry.IsVisible;
                 entry.UpdateVisibility();
@@ -419,13 +421,18 @@ namespace MWC_Localization_Core
                 // Only translate when visibility changes from hidden to visible
                 if (!wasVisible && entry.IsVisible)
                 {
-                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
+                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
                     if (translated)
                     {
                         entry.WasTranslated = true;
                         entry.UpdateLastText();
                     }
                 }
+            }
+
+            foreach (int instanceID in removalBuffer)
+            {
+                UnregisterInstance(instanceID);
             }
         }
 


### PR DESCRIPTION
- Removed unused modes/routes: `RegexExtract`, `CommaSeparated`, `TranslateOnce`, `SlowPolling`, dead `PatternMatcher` APIs, and `TranslateMultilineByLines`
- Removed dead duplicate magazine pattern handling in `PatternMatcher.cs` (now handled exclusively by `MagazineTextHandler`)
- Optimized scene translation in `MWC_Localization_Core.cs`: translation and forced font application now run in a single `TextMesh` pass, eliminating the need for a second global sweep
- Factored duplicated GAME scene initialization flow into `InitializeGameDataSources`
- Reduced overhead in `UnifiedTextMeshMonitor.cs` by removing the unused `pathToInstances` index
- Improved stability in `TextMeshTranslator.cs`: `renderer.material` is now cached per renderer, preventing repeated material instantiation
- Replaced `GameObject.Find` (menu) with `MLCUtils.FindGameObjectCached`

- Changed monitoring strategy from `OnVisibilityChange` to `Persistent` for:
  - `Sheets/RallyResults`
  - `Sheets/RallyRegistration/Functions/Class` This fixes missed translations when opening sheets rapidly or multiple times, where visibility-based triggers were unreliable

Section monitored by chatGPT 5.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime texture caching to optimize performance during text translation operations.

* **Bug Fixes**
  * Improved GameObject lookup performance through caching mechanisms.
  * Enhanced key-based translation matching with proper text unescaping.

* **Refactor**
  * Simplified translation system by removing regex and comma-separated translation modes.
  * Removed magazine-specific pattern handling and related public APIs.
  * Streamlined scene translation and initialization processes.
  * Cleaned up unused namespace imports across multiple modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->