### PR TITLE
refactor: unify key normalization, remove dead code, and optimize translation pipeline

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -1,10 +1,8 @@
 // Generic handler for translating PlayMakerArrayListProxy data
 // Supports any GameObject with array-based content (HUD, menus, etc.)
 
-using MSCLoader;
 using UnityEngine;
 using System.Collections.Generic;
-using System.Text;
 using System.Collections;
 
 namespace MWC_Localization_Core

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -86,10 +86,7 @@ namespace MWC_Localization_Core
 
         public void ClearTranslations()
         {
-            translatedArrays.Clear();
-            arrayProxyCache.Clear();
-            fontAppliedInstances.Clear();
-            completedParentPaths.Clear();
+            Reset();
         }
 
         public void Reset()

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -18,14 +18,12 @@ namespace MWC_Localization_Core
         private PatternMatcher patternMatcher;
         private string appliedTarget;
         private HashSet<string> loggedReadyTargets = new HashSet<string>();
-        private HashSet<string> completedStrategyTargets = new HashSet<string>();
-        private HashSet<int> completedEnnusteFsmInstances = new HashSet<int>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
         private float lastEnnusteDataFsmScanTime = -10f;
 
         private static readonly WaitForSeconds BootstrapPollDelay = new WaitForSeconds(0.5f);
-        private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(3.0f);
-        private const float EnnusteDataRescanInterval = 10f;
+        private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(1.0f);
+        private const float EnnusteDataRescanInterval = 2f;
 
         // Reflection cache: (Type, fieldName) -> FieldInfo to avoid repeated GetField calls
         private static readonly Dictionary<System.Type, Dictionary<string, FieldInfo>> reflectionCache
@@ -380,13 +378,8 @@ namespace MWC_Localization_Core
                 if (!IsFsmReady(fsm))
                     continue;
 
-                int instanceID = fsm.GetInstanceID();
-                if (completedEnnusteFsmInstances.Contains(instanceID))
-                    continue;
-
                 LogReadyOnce("TTX_WX_READY", "[FsmTextHook] Teletext weather updater FSM targets are ready.");
                 ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
-                completedEnnusteFsmInstances.Add(instanceID);
             }
 
             if (anyChanged)
@@ -438,42 +431,20 @@ namespace MWC_Localization_Core
                 if (target == null)
                     continue;
 
-                string targetKey = BuildTargetKey(target);
-                if (completedStrategyTargets.Contains(targetKey))
-                    continue;
-
                 PlayMakerFSM fsm = MLCUtils.FindFsmIncludingInactiveByPathAndName(target.ObjectPath, target.FsmName);
                 if (!IsFsmReady(fsm))
                     continue;
 
                 LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
 
-                bool strategyChanged;
-                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget, out strategyChanged);
-
-                // ConlineChatStatus reaches through nested FsmString properties and may not
-                // succeed on the first ready check even when the FSM reports Initialized.
-                // Keep retrying that strategy until it actually translates something; every
-                // other strategy is fine to mark complete immediately.
-                if (strategyChanged || target.Strategy != FsmStrategyType.ConlineChatStatus)
-                {
-                    completedStrategyTargets.Add(targetKey);
-                }
+                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
             }
         }
 
-        private static string BuildTargetKey(FsmStrategyTarget target)
+        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
         {
-            return target.ObjectPath + "|" + target.FsmName + "|" + target.Strategy.ToString() + "|" + target.StateName + "|" + target.ActionIndex.ToString();
-        }
-
-        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget, out bool strategyChanged)
-        {
-            strategyChanged = false;
             if (target == null || fsm == null)
                 return;
-
-            bool beforeChanged = anyChanged;
 
             switch (target.Strategy)
             {
@@ -533,8 +504,6 @@ namespace MWC_Localization_Core
             {
                 appliedTarget = target.AppliedLabel;
             }
-
-            strategyChanged = (anyChanged != beforeChanged);
         }
 
         private void LogReadyOnce(string key, string message)
@@ -667,25 +636,10 @@ namespace MWC_Localization_Core
             lastEnnusteDataFsmScanTime = Time.realtimeSinceStartup;
             cachedEnnusteDataFsms.Clear();
 
-            PlayMakerFSM[] allFsms = Resources.FindObjectsOfTypeAll<PlayMakerFSM>();
-            if (allFsms == null)
-                return cachedEnnusteDataFsms;
-
-            for (int i = 0; i < allFsms.Length; i++)
-            {
-                PlayMakerFSM fsm = allFsms[i];
-                if (fsm == null || fsm.gameObject == null)
-                    continue;
-
-                if (fsm.FsmName != "Data")
-                    continue;
-
-                string path = MLCUtils.GetGameObjectPath(fsm.gameObject);
-                if (path.StartsWith(TeletextEnnusteUpdaterPrefix))
-                {
-                    cachedEnnusteDataFsms.Add(fsm);
-                }
-            }
+            MLCUtils.FindFsmsIncludingInactiveByPathPrefixAndName(
+                TeletextEnnusteUpdaterPrefix,
+                "Data",
+                cachedEnnusteDataFsms);
 
             return cachedEnnusteDataFsms;
         }

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -307,8 +307,8 @@ namespace MWC_Localization_Core
 
         private bool TryApplyMainMenuTranslations()
         {
-            GameObject folkObj = GameObject.Find("Radio/Folk");
-            GameObject cdObj = GameObject.Find("Radio/CD");
+            GameObject folkObj = MLCUtils.FindGameObjectCached("Radio/Folk");
+            GameObject cdObj = MLCUtils.FindGameObjectCached("Radio/CD");
 
             if (folkObj == null || cdObj == null)
                 return false;

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -1,5 +1,3 @@
-using MSCLoader;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -33,8 +33,7 @@ namespace MWC_Localization_Core
 
         public void ClearTranslations()
         {
-            translatedPaths.Clear();
-            proxyCache.Clear();
+            Reset();
         }
 
         public void Reset()

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -1,6 +1,4 @@
-using MSCLoader;
 using UnityEngine;
-using System.Collections.Generic;
 
 namespace MWC_Localization_Core
 {

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -1,6 +1,5 @@
 // Configuration file loader
 
-using MSCLoader;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -37,8 +37,11 @@ namespace MWC_Localization_Core
         private static Dictionary<GameObject, string> pathCache = new Dictionary<GameObject, string>();
         // Cache for expensive GameObject.Find(path) lookups
         private static Dictionary<string, GameObject> gameObjectFindCache = new Dictionary<string, GameObject>();
-        // Cache for inactive lookup helpers (resolved via Resources.FindObjectsOfTypeAll)
+        // Scene-local FSM index for inactive lookup helpers (resolved via Resources.FindObjectsOfTypeAll)
         private static Dictionary<string, PlayMakerFSM> inactiveFsmPathNameCache = new Dictionary<string, PlayMakerFSM>();
+        private static bool fsmIndexBuilt = false;
+        private static float lastFsmIndexBuildTime = -1000f;
+        private const float FSM_INDEX_REFRESH_INTERVAL = 1f;
 
         public static string GetGameObjectPath(GameObject obj)
         {
@@ -109,33 +112,82 @@ namespace MWC_Localization_Core
 
             string cacheKey = objectPath + "|" + fsmName;
 
-            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out PlayMakerFSM cachedFsm))
-            {
-                if (cachedFsm != null && cachedFsm.gameObject != null)
-                    return cachedFsm;
+            EnsureFsmIndexFresh();
 
-                inactiveFsmPathNameCache.Remove(cacheKey);
+            PlayMakerFSM cachedFsm;
+            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm)
+                && cachedFsm != null
+                && cachedFsm.gameObject != null)
+            {
+                return cachedFsm;
             }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Find PlayMakerFSMs by path prefix + FSM name, including inactive objects.
+        /// Results are written into the provided list to avoid per-call allocations.
+        /// </summary>
+        public static void FindFsmsIncludingInactiveByPathPrefixAndName(string pathPrefix, string fsmName, List<PlayMakerFSM> results)
+        {
+            if (results == null)
+                return;
+
+            results.Clear();
+            if (string.IsNullOrEmpty(pathPrefix) || string.IsNullOrEmpty(fsmName))
+                return;
+
+            EnsureFsmIndexFresh();
+
+            foreach (PlayMakerFSM fsm in inactiveFsmPathNameCache.Values)
+            {
+                if (fsm == null || fsm.gameObject == null)
+                    continue;
+
+                if (fsm.FsmName != fsmName)
+                    continue;
+
+                string path = GetGameObjectPath(fsm.gameObject);
+                if (path.StartsWith(pathPrefix))
+                {
+                    results.Add(fsm);
+                }
+            }
+        }
+
+        private static void EnsureFsmIndexFresh()
+        {
+            float now = Time.realtimeSinceStartup;
+            if (fsmIndexBuilt && now - lastFsmIndexBuildTime < FSM_INDEX_REFRESH_INTERVAL)
+                return;
+
+            RebuildFsmIndex(now);
+        }
+
+        private static void RebuildFsmIndex(float timestamp)
+        {
+            inactiveFsmPathNameCache.Clear();
+            lastFsmIndexBuildTime = timestamp;
+            fsmIndexBuilt = true;
 
             PlayMakerFSM[] allFsms = Resources.FindObjectsOfTypeAll<PlayMakerFSM>();
             if (allFsms == null)
-                return null;
+                return;
 
             for (int i = 0; i < allFsms.Length; i++)
             {
                 PlayMakerFSM fsm = allFsms[i];
-                if (fsm == null || fsm.gameObject == null)
+                if (fsm == null || fsm.gameObject == null || string.IsNullOrEmpty(fsm.FsmName))
                     continue;
 
                 string path = GetGameObjectPath(fsm.gameObject);
-                if (path == objectPath && fsm.FsmName == fsmName)
+                string key = path + "|" + fsm.FsmName;
+                if (!inactiveFsmPathNameCache.ContainsKey(key))
                 {
-                    inactiveFsmPathNameCache[cacheKey] = fsm;
-                    return fsm;
+                    inactiveFsmPathNameCache[key] = fsm;
                 }
             }
-
-            return null;
         }
 
         /// <summary>
@@ -155,6 +207,8 @@ namespace MWC_Localization_Core
             pathCache.Clear();
             gameObjectFindCache.Clear();
             inactiveFsmPathNameCache.Clear();
+            fsmIndexBuilt = false;
+            lastFsmIndexBuildTime = -1000f;
         }
     }
 }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -145,25 +145,7 @@ namespace MWC_Localization_Core
             TranslateScene();
             sceneManager.MarkSceneTranslated("GAME");
             InitializeFsmTextHook();
-            
-            // Reset handlers
-            teletextHandler.Reset();
-            arrayListHandler.Reset();
-            hashTableHandler.Reset();
-
-            // Translate static arrays immediately
-            int arrayTranslated = arrayListHandler.TranslateAllArrays();
-            if (arrayTranslated > 0)
-            {
-                CoreConsole.Print($"[{Name}] Translated {arrayTranslated} array items");
-                arrayListHandler.ApplyFontsToArrayElements();
-            }
-
-            int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
-            if (hashTableTranslated > 0)
-            {
-                CoreConsole.Print($"[{Name}] Translated {hashTableTranslated} hash table items");
-            }
+            InitializeGameDataSources("");
             
             // Create MonoBehaviour for LateUpdate monitoring
             // ALL continuous monitoring logic runs in LateUpdate to ensure correct timing
@@ -252,26 +234,27 @@ namespace MWC_Localization_Core
                 TranslateScene();
                 sceneManager.MarkSceneTranslated("GAME");
                 InitializeFsmTextHook();
-                
-                // Reset teletext handler and retry tracking for new scene
-                teletextHandler.Reset();
-                arrayListHandler.Reset();
-                hashTableHandler.Reset();
-                
-                // Translate static arrays immediately (HUD, menus, etc.)
-                int arrayTranslated = arrayListHandler.TranslateAllArrays();
-                if (arrayTranslated > 0)
-                {
-                    CoreConsole.Print($"[{Name}] [Arrays] Initial translation: {arrayTranslated} items");
-                    // Apply Korean fonts to TextMesh components using array data
-                    arrayListHandler.ApplyFontsToArrayElements();
-                }
+                InitializeGameDataSources("Initial ");
+            }
+        }
 
-                int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
-                if (hashTableTranslated > 0)
-                {
-                    CoreConsole.Print($"[{Name}] [HashTables] Initial translation: {hashTableTranslated} items");
-                }
+        private void InitializeGameDataSources(string logPrefix)
+        {
+            teletextHandler.Reset();
+            arrayListHandler.Reset();
+            hashTableHandler.Reset();
+
+            int arrayTranslated = arrayListHandler.TranslateAllArrays();
+            if (arrayTranslated > 0)
+            {
+                CoreConsole.Print($"[{Name}] {logPrefix}translated {arrayTranslated} array items");
+                arrayListHandler.ApplyFontsToArrayElements();
+            }
+
+            int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
+            if (hashTableTranslated > 0)
+            {
+                CoreConsole.Print($"[{Name}] {logPrefix}translated {hashTableTranslated} hash table items");
             }
         }
 
@@ -553,52 +536,33 @@ namespace MWC_Localization_Core
             // Find all TextMesh components in the scene
             TextMesh[] allTextMeshes = MLCUtils.GetAllTextMeshesIncludingInactive();
             int translatedCount = 0;
+            int forcedFontAppliedCount = 0;
 
             foreach (TextMesh tm in allTextMeshes)
             {
-                if (tm == null || string.IsNullOrEmpty(tm.text))
+                if (tm == null)
                     continue;
 
                 // Get GameObject path
                 string path = MLCUtils.GetGameObjectPath(tm.gameObject);
 
                 // Translate and apply font
-                bool translated = translator.TranslateAndApplyFont(tm, path, null);
-                if (translated)
+                if (!string.IsNullOrEmpty(tm.text))
                 {
-                    translatedCount++;
+                    bool translated = translator.TranslateAndApplyFont(tm, path);
+                    if (translated)
+                    {
+                        translatedCount++;
+                    }
+                }
+
+                if (PathStartsWithAny(path, ForcedFontPathPrefixes) && translator.ApplyFontOnly(tm, path))
+                {
+                    forcedFontAppliedCount++;
                 }
             }
-
-            int forcedFontAppliedCount = ApplyForcedFontPass(allTextMeshes);
 
             CoreConsole.Print($"[{Name}] Scene translation complete: {translatedCount}/{allTextMeshes.Length} TextMesh objects translated, forced font pass: {forcedFontAppliedCount}");
-        }
-
-        private int ApplyForcedFontPass(TextMesh[] allTextMeshes)
-        {
-            if (translator == null || allTextMeshes == null || allTextMeshes.Length == 0)
-                return 0;
-
-            int appliedCount = 0;
-
-            for (int i = 0; i < allTextMeshes.Length; i++)
-            {
-                TextMesh tm = allTextMeshes[i];
-                if (tm == null)
-                    continue;
-
-                string path = MLCUtils.GetGameObjectPath(tm.gameObject);
-                if (!PathStartsWithAny(path, ForcedFontPathPrefixes))
-                    continue;
-
-                if (translator.ApplyFontOnly(tm, path))
-                {
-                    appliedCount++;
-                }
-            }
-
-            return appliedCount;
         }
 
         private bool PathStartsWithAny(string path, string[] prefixes)

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -2,7 +2,6 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace MWC_Localization_Core
 {
@@ -321,51 +320,18 @@ namespace MWC_Localization_Core
 
         void InsertTranslationLines(string translationPath)
         {
-            try
+            Dictionary<string, string> loadedTranslations = TranslationFileParser.ParseKeyValueFile(
+                translationPath,
+                normalizeKeys: true,
+                overwriteExisting: true);
+
+            foreach (var pair in loadedTranslations)
             {
-                string[] lines = File.ReadAllLines(translationPath, Encoding.UTF8);
-
-                foreach (string line in lines)
-                {
-                    if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith("#"))
-                        continue;
-
-                    int separatorIndex = TranslationFileParser.FindKeyValueSeparator(line);
-                    if (separatorIndex > 0)
-                    {
-                        string rawKey = line.Substring(0, separatorIndex).Trim();
-                        string rawValue = line.Substring(separatorIndex + 1);
-
-                        // Unescape \= -> = in key; apply full unescape (\= and \n) to value
-                        string unescapedKey = rawKey.Replace("\\=", "=");
-                        string unescapedValue = TranslationFileParser.UnescapeValue(rawValue);
-
-                        // Common authoring style is: "key = value".
-                        // In that specific case, drop only the single separator space so
-                        // intentional leading/trailing spacing is preserved.
-                        if (line.Length > separatorIndex + 1 && line[separatorIndex + 1] == ' ')
-                        {
-                            bool hasSecondSpace = (line.Length > separatorIndex + 2 && line[separatorIndex + 2] == ' ');
-                            if (!hasSecondSpace && unescapedValue.Length > 0 && unescapedValue[0] == ' ')
-                                unescapedValue = unescapedValue.Substring(1);
-                        }
-
-                        string normalizedKey = MLCUtils.FormatUpperKey(unescapedKey);
-
-                        if (!string.IsNullOrEmpty(normalizedKey))
-                        {
-                            translations[normalizedKey] = unescapedValue;
-                        }
-                    }
-                }
-
-                hasLoadedTranslations = true;
-                CoreConsole.Print($"[{Name}] Loaded {translations.Count} translations from {Path.GetFileName(translationPath)}");
+                translations[pair.Key] = pair.Value;
             }
-            catch (System.Exception ex)
-            {
-                CoreConsole.Error($"[{Name}] Failed to load translations: {ex.Message}");
-            }
+
+            hasLoadedTranslations = true;
+            CoreConsole.Print($"[{Name}] Loaded {loadedTranslations.Count} translations from {Path.GetFileName(translationPath)} ({translations.Count} total)");
         }
 
         void LoadTranslations()

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -248,8 +248,8 @@ namespace MWC_Localization_Core
             if (arrayTranslated > 0)
             {
                 CoreConsole.Print($"[{Name}] {logPrefix}translated {arrayTranslated} array items");
-                arrayListHandler.ApplyFontsToArrayElements();
             }
+            arrayListHandler.ApplyFontsToArrayElements();
 
             int hashTableTranslated = hashTableHandler.TranslateAllHashTables();
             if (hashTableTranslated > 0)

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -1,9 +1,6 @@
 // 'Classified Magazine' Text Handler
 
-using MSCLoader;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using UnityEngine;
 
 namespace MWC_Localization_Core

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -6,12 +6,6 @@ namespace MWC_Localization_Core
     public enum MonitoringStrategy
     {
         /// <summary>
-        /// Translate once during the initial scene scan, then stop monitoring.
-        /// Use for static UI elements that never change.
-        /// </summary>
-        TranslateOnce,
-
-        /// <summary>
         /// Monitor every frame without throttling.
         /// Use for interaction prompts, subtitles, and other critical real-time UI.
         /// </summary>
@@ -22,12 +16,6 @@ namespace MWC_Localization_Core
         /// Use for active HUD elements that update frequently.
         /// </summary>
         FastPolling,
-
-        /// <summary>
-        /// Monitor at a slow polling interval for less critical content.
-        /// Use for teletext, FSM-generated content, and weather displays.
-        /// </summary>
-        SlowPolling,
 
         /// <summary>
         /// Keep checking even after translation for content that is frequently rebuilt.
@@ -62,24 +50,9 @@ namespace MWC_Localization_Core
     public enum TranslationMode
     {
         /// <summary>
-        /// Simple dictionary lookup for exact text keys.
-        /// </summary>
-        SimpleLookup,
-
-        /// <summary>
         /// Pattern matching with {0}, {1}, and similar placeholders.
         /// </summary>
         FsmPattern,
-
-        /// <summary>
-        /// Regular expression extraction and replacement.
-        /// </summary>
-        RegexExtract,
-
-        /// <summary>
-        /// Split by comma and translate each item independently.
-        /// </summary>
-        CommaSeparated,
 
         /// <summary>
         /// Use a custom handler for more complex translation logic.

--- a/PatternMatcher.cs
+++ b/PatternMatcher.cs
@@ -1,6 +1,5 @@
 // Pattern matching system for Translation Strings
 
-using MSCLoader;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -39,29 +38,6 @@ namespace MWC_Localization_Core
         /// </summary>
         private void InitializeBuiltInPatterns()
         {
-            // Magazine price/phone pattern (custom handler)
-            var magazinePricePattern = new TranslationPattern(
-                "MagazinePrice",
-                TranslationMode.CustomHandler,
-                "h.{price},- puh.{phone}",
-                "{price} MK, {PHONE} - {phone}"
-            );
-            magazinePricePattern.PathMatcher = path => path.Contains("YellowPagesMagazine");
-            magazinePricePattern.TextMatcher = text => text.StartsWith("h.") && text.Contains(",- puh.");
-            magazinePricePattern.CustomHandler = TranslateMagazinePriceLine;
-            AddPatternInternal(magazinePricePattern, true);
-
-            // Magazine comma-separated words
-            var magazineWordsPattern = new TranslationPattern(
-                "MagazineWords",
-                TranslationMode.CommaSeparated,
-                "",
-                ""
-            );
-            magazineWordsPattern.PathMatcher = path => path.Contains("YellowPagesMagazine");
-            magazineWordsPattern.TextMatcher = text => text.Split(',').Length == 3;
-            AddPatternInternal(magazineWordsPattern, true);
-
             // Multi-line Computer command text handler
             var pcScreenPattern = new TranslationPattern(
                 "PCMultiLine",
@@ -89,7 +65,6 @@ namespace MWC_Localization_Core
             try
             {
                 string[] lines = File.ReadAllLines(filePath, Encoding.UTF8);
-                string currentSection = null;
                 int loadedCount = 0;
 
                 foreach (string line in lines)
@@ -103,7 +78,6 @@ namespace MWC_Localization_Core
                     // Check for section header
                     if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
                     {
-                        currentSection = trimmed.Substring(1, trimmed.Length - 2);
                         continue;
                     }
 
@@ -176,8 +150,8 @@ namespace MWC_Localization_Core
             string upperText = null;
             foreach (var pattern in patterns)
             {
-                // CustomHandler patterns work on original text; FSM/Regex need uppercase
-                bool needsUpper = pattern.Mode != TranslationMode.CustomHandler && pattern.Mode != TranslationMode.CommaSeparated;
+                // CustomHandler patterns work on original text; FSM patterns need uppercase
+                bool needsUpper = pattern.Mode != TranslationMode.CustomHandler;
                 string inputText;
                 if (needsUpper)
                 {
@@ -198,23 +172,6 @@ namespace MWC_Localization_Core
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Add a pattern programmatically
-        /// </summary>
-        public void AddPattern(TranslationPattern pattern)
-        {
-            AddPatternInternal(pattern, false);
-        }
-
-        /// <summary>
-        /// Clear all patterns
-        /// </summary>
-        public void ClearPatterns()
-        {
-            patterns.Clear();
-            patternSignatures.Clear();
         }
 
         private bool AddPatternInternal(TranslationPattern pattern, bool appendToEnd)
@@ -247,42 +204,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Custom handler for magazine price/phone lines
-        /// Format: "h.149,- puh.123456" -> "149 MK, PHONE - 123456"
-        /// </summary>
-        private TranslationPattern.CustomHandlerResult TranslateMagazinePriceLine(string text, string path, Dictionary<string, string> translations)
-        {
-            try
-            {
-                // Remove "h." prefix and split by ",- puh."
-                if (!text.StartsWith("h."))
-                    return new TranslationPattern.CustomHandlerResult(false, null);
-
-                string withoutPrefix = text.Substring(2);
-                string[] parts = withoutPrefix.Split(new string[] { ",- puh." }, System.StringSplitOptions.None);
-
-                if (parts.Length == 2)
-                {
-                    string pricePart = parts[0].Trim();
-                    string phonePart = parts[1].Trim();
-
-                    // Get phone label from translations
-                    string phoneLabel = translations.TryGetValue("PHONE", out string translation)
-                        ? translation
-                        : "PHONE";
-
-                    return new TranslationPattern.CustomHandlerResult(true, $"{pricePart} MK, {phoneLabel} - {phonePart}");
-                }
-            }
-            catch (System.Exception ex)
-            {
-                CoreConsole.Warning($"Failed to parse magazine price/phone line: {text} - {ex.Message}");
-            }
-
-            return new TranslationPattern.CustomHandlerResult(false, null);
-        }
-
-        /// <summary>
         /// Custom handler for multi-line computer screen text
         /// Splits lines and translates each line individually
         private TranslationPattern.CustomHandlerResult TranslateMultilineScreen(string text, string path, Dictionary<string, string> translations)
@@ -304,7 +225,7 @@ namespace MWC_Localization_Core
                     }
 
                     // Try to translate this line
-                    string key = trimmed.ToUpperInvariant();
+                    string key = MLCUtils.FormatUpperKey(trimmed);
                     if (translations.TryGetValue(key, out string translation))
                     {
                         translatedLines.Add(translation);

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -64,10 +64,9 @@ namespace MWC_Localization_Core
 
             if (currentScene != newScene)
             {
-                string previousScene = currentScene;
                 currentScene = newScene;
                 
-                HandleSceneChange(previousScene, currentScene);
+                HandleSceneChange(currentScene);
                 
                 return true;
             }
@@ -78,7 +77,7 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Handle scene-specific cleanup/reset logic
         /// </summary>
-        private void HandleSceneChange(string from, string to)
+        private void HandleSceneChange(string to)
         {
             if (to == "MainMenu")
             {

--- a/SceneTranslationManager.cs
+++ b/SceneTranslationManager.cs
@@ -1,5 +1,3 @@
-using MSCLoader;
-
 namespace MWC_Localization_Core
 {
     /// <summary>
@@ -14,8 +12,6 @@ namespace MWC_Localization_Core
         
         // Current scene tracking
         private string currentScene = "";
-        private string previousScene = "";
-
         public SceneTranslationManager()
         {
         }
@@ -68,7 +64,7 @@ namespace MWC_Localization_Core
 
             if (currentScene != newScene)
             {
-                previousScene = currentScene;
+                string previousScene = currentScene;
                 currentScene = newScene;
                 
                 HandleSceneChange(previousScene, currentScene);

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -207,21 +207,25 @@ namespace MWC_Localization_Core
                     string normalizedOriginal = original.Trim();
                     if (string.IsNullOrEmpty(normalizedOriginal))
                         continue;
+                    string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
 
                     // Keep fallback alignment based on non-empty source entries only.
                     nonEmptySourceIndex++;
                     
                     // Try exact key match first
-                    if (translations.TryGetValue(normalizedOriginal, out string translation))
+                    if (translations.TryGetValue(translationKey, out string translation))
                     {
-                        arrayList[i] = translation;
-                        translatedCount++;
+                        if (original != translation)
+                        {
+                            arrayList[i] = translation;
+                            translatedCount++;
+                        }
                     }
                     // Fallback: Use index-based translation if available
                     else if (hasIndexFallback && nonEmptySourceIndex < indexBasedTranslations[categoryName].Count)
                     {
                         string indexTranslation = indexBasedTranslations[categoryName][nonEmptySourceIndex];
-                        if (!string.IsNullOrEmpty(indexTranslation))
+                        if (!string.IsNullOrEmpty(indexTranslation) && original != indexTranslation)
                         {
                             arrayList[i] = indexTranslation;
                             translatedCount++;

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -1,4 +1,3 @@
-using MSCLoader;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -17,6 +16,7 @@ namespace MWC_Localization_Core
         private LocalizationConfig config;
         private Dictionary<int, string> appliedFontCache = new Dictionary<int, string>();
         private Dictionary<int, Texture> appliedRuntimeTextureCache = new Dictionary<int, Texture>();
+        private Dictionary<int, Material> runtimeMaterialCache = new Dictionary<int, Material>();
         private Dictionary<string, Font> fontNameToFont;  // Reverse lookup: font.name -> Font
 
         private static readonly string[] ExcludedPath = new string[]
@@ -61,16 +61,11 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Translate TextMesh and apply custom font + position adjustments
         /// </summary>
-        /// <param name="translatedTextMeshes">HashSet tracking which TextMesh objects have been translated</param>
         /// <returns>True if text was translated or already localized</returns>
-        public bool TranslateAndApplyFont(TextMesh textMesh, string path, HashSet<TextMesh> translatedTextMeshes)
+        public bool TranslateAndApplyFont(TextMesh textMesh, string path)
         {
             if (textMesh == null || string.IsNullOrEmpty(textMesh.text))
                 return false;
-
-            // Skip if already translated (language-agnostic check)
-            if (translatedTextMeshes != null && translatedTextMeshes.Contains(textMesh))
-                return true;
 
             // Skip excluded paths
             foreach(string excluded in ExcludedPath)
@@ -79,12 +74,18 @@ namespace MWC_Localization_Core
                     return false;
             }
 
-            // Try complex text handling first (e.g., magazine text, cashier price)
-            if (HandleComplexTextMesh(textMesh, path))
+            if (magazineHandler.IsMagazineText(path))
+            {
+                ApplyCustomFont(textMesh, path);
+                magazineHandler.HandleMagazineText(textMesh);
+                return true;
+            }
+
+            // Use standard translation before pattern matching; dictionary lookup is cheaper.
+            if (ApplyTranslation(textMesh, path))
                 return true;
 
-            // Use standard translation
-            if (ApplyTranslation(textMesh, path))
+            if (ApplyPatternTranslation(textMesh, path))
                 return true;
 
             return false;
@@ -129,15 +130,26 @@ namespace MWC_Localization_Core
 
                     if (needsTextureApply && targetMainTexture != null)
                     {
-                        // Always preserve original material properties (colors, tints, etc.) by swapping only the atlas texture.
-                        // This works for both TV and non-TV paths and preserves custom colors like yellow text.
-                        Material runtimeMaterial = renderer.material;
-                        if (runtimeMaterial != null && runtimeMaterial.mainTexture != targetMainTexture)
+                        Material runtimeMaterial;
+                        if (!runtimeMaterialCache.TryGetValue(rendererInstanceID, out runtimeMaterial) || runtimeMaterial == null)
                         {
-                            runtimeMaterial.mainTexture = targetMainTexture;
+                            // Preserve per-renderer material properties while avoiding repeated renderer.material instantiation.
+                            runtimeMaterial = renderer.material;
+                            if (runtimeMaterial != null)
+                            {
+                                runtimeMaterialCache[rendererInstanceID] = runtimeMaterial;
+                            }
                         }
 
-                        appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
+                        if (runtimeMaterial != null)
+                        {
+                            if (runtimeMaterial.mainTexture != targetMainTexture)
+                            {
+                                runtimeMaterial.mainTexture = targetMainTexture;
+                            }
+
+                            appliedRuntimeTextureCache[rendererInstanceID] = targetMainTexture;
+                        }
                     }
                 }
 
@@ -146,32 +158,19 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Handle complex text patterns (magazine text, cashier price line)
-        /// Now uses unified pattern matcher for all pattern-based translations
+        /// Handle pattern-based text translations.
         /// </summary>
-        bool HandleComplexTextMesh(TextMesh textMesh, string path)
+        bool ApplyPatternTranslation(TextMesh textMesh, string path)
         {
-            // Check magazine text FIRST - it requires special handling (comma-separated words, price/phone format)
-            if (magazineHandler.IsMagazineText(path))
-            {
-                // Apply custom font first
-                ApplyCustomFont(textMesh, path);
-                // Apply Translation
-                return magazineHandler.HandleMagazineText(textMesh);
-            }
-            
-            // Try pattern matching for other complex texts (FSM, Price patterns)
             string patternResult = patternMatcher.TryTranslateWithPattern(textMesh.text, path);
             if (patternResult != null)
             {
-                // Apply custom font first
                 ApplyCustomFont(textMesh, path);
-                // Apply Translation
                 textMesh.text = patternResult;
                 return true;
             }
 
-            return false; // Not handled, use standard translation
+            return false;
         }
 
         /// <summary>
@@ -200,45 +199,6 @@ namespace MWC_Localization_Core
             // Apply translation
             textMesh.text = translation;
 
-            return true;
-        }
-
-        /// <summary>
-        /// Translate multiline text line-by-line.
-        /// Useful for dynamic displays that append lines over time.
-        /// </summary>
-        public bool TranslateMultilineByLines(TextMesh textMesh, string path)
-        {
-            if (textMesh == null || string.IsNullOrEmpty(textMesh.text))
-                return false;
-
-            string original = textMesh.text;
-            string[] lines = original.Split('\n');
-            bool changed = false;
-
-            for (int i = 0; i < lines.Length; i++)
-            {
-                string line = lines[i];
-                if (string.IsNullOrEmpty(line))
-                    continue;
-
-                string trimmedCr = line.Replace("\r", string.Empty);
-                string normalizedKey = MLCUtils.FormatUpperKey(trimmedCr);
-                if (string.IsNullOrEmpty(normalizedKey))
-                    continue;
-
-                if (translations.TryGetValue(normalizedKey, out string translatedLine) && trimmedCr != translatedLine)
-                {
-                    lines[i] = translatedLine;
-                    changed = true;
-                }
-            }
-
-            if (!changed)
-                return false;
-
-            ApplyCustomFont(textMesh, path);
-            textMesh.text = string.Join("\n", lines);
             return true;
         }
 
@@ -295,6 +255,7 @@ namespace MWC_Localization_Core
         {
             appliedFontCache.Clear();
             appliedRuntimeTextureCache.Clear();
+            runtimeMaterialCache.Clear();
         }
     }
 }

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -15,7 +15,7 @@ namespace MWC_Localization_Core
         /// Parse KEY=VALUE translation file (simple format)
         /// Supports escaped equals (\=) and preserves intentional spacing
         /// </summary>
-        public static Dictionary<string, string> ParseKeyValueFile(string filePath, bool normalizeKeys = true)
+        public static Dictionary<string, string> ParseKeyValueFile(string filePath, bool normalizeKeys = true, bool overwriteExisting = false)
         {
             var result = new Dictionary<string, string>();
 
@@ -59,7 +59,7 @@ namespace MWC_Localization_Core
 
                     string processedValue = value.Replace("\\n", "\n");
 
-                    if (!result.ContainsKey(key))
+                    if (overwriteExisting || !result.ContainsKey(key))
                         result[key] = processedValue;
                 }
             }

--- a/TranslationPattern.cs
+++ b/TranslationPattern.cs
@@ -1,17 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using UnityEngine;
 
 namespace MWC_Localization_Core
 {
     /// <summary>
     /// Represents a translation pattern with extraction and formatting logic
-    /// Supports placeholders, regex, comma-separated values, and custom handlers
+    /// Supports placeholders and custom handlers
     /// </summary>
     public class TranslationPattern
     {
-        public string Name { get; private set; }
         public TranslationMode Mode { get; private set; }
         public string OriginalPattern { get; private set; }
         public string TranslatedTemplate { get; private set; }
@@ -22,11 +19,6 @@ namespace MWC_Localization_Core
         
         // For FsmPattern mode
         private string[] originalParts;
-        private string[] translationParts;
-        
-        // For RegexExtract mode
-        private Regex regexPattern;
-        
         // For CustomHandler mode
         public Func<string, string, Dictionary<string, string>, CustomHandlerResult> CustomHandler { get; set; }
         
@@ -45,7 +37,6 @@ namespace MWC_Localization_Core
 
         public TranslationPattern(string name, TranslationMode mode, string originalPattern, string translatedTemplate)
         {
-            Name = name;
             Mode = mode;
             OriginalPattern = originalPattern;
             TranslatedTemplate = translatedTemplate;
@@ -61,10 +52,6 @@ namespace MWC_Localization_Core
                 case TranslationMode.FsmPatternWithTranslation:
                     InitializeFsmPattern();
                     break;
-                    
-                case TranslationMode.RegexExtract:
-                    InitializeRegexPattern();
-                    break;
             }
         }
 
@@ -73,7 +60,6 @@ namespace MWC_Localization_Core
             // Split patterns by placeholders to get static parts
             // Example: "pakkasta {0} astetta" -> ["pakkasta ", " astetta"]
             originalParts = SplitPattern(OriginalPattern);
-            translationParts = SplitPattern(TranslatedTemplate);
         }
 
         private string[] SplitPattern(string pattern)
@@ -114,18 +100,6 @@ namespace MWC_Localization_Core
             return parts.ToArray();
         }
 
-        private void InitializeRegexPattern()
-        {
-            try
-            {
-                regexPattern = new Regex(OriginalPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError($"Failed to compile regex pattern '{OriginalPattern}': {ex.Message}");
-            }
-        }
-
         /// <summary>
         /// Check if this pattern matches the given text and path
         /// </summary>
@@ -145,13 +119,10 @@ namespace MWC_Localization_Core
                 case TranslationMode.FsmPattern:
                 case TranslationMode.FsmPatternWithTranslation:
                     return TryExtractFsmValues(text) != null;
-                    
-                case TranslationMode.RegexExtract:
-                    return regexPattern != null && regexPattern.IsMatch(text);
-                    
-                case TranslationMode.CommaSeparated:
-                    return text.Contains(",");
-                    
+
+                case TranslationMode.CustomHandler:
+                    return CustomHandler != null;
+
                 default:
                     return false;
             }
@@ -173,13 +144,6 @@ namespace MWC_Localization_Core
                     
                 case TranslationMode.FsmPatternWithTranslation:
                     return TranslateWithFsmPatternAndTranslateParams(text, translations);
-                    
-                case TranslationMode.RegexExtract:
-                    return TranslateWithRegex(text, translations);
-                    
-                case TranslationMode.CommaSeparated:
-                    return TranslateCommaSeparated(text, translations);
-                    
                 case TranslationMode.CustomHandler:
                     if (CustomHandler != null)
                     {
@@ -294,55 +258,6 @@ namespace MWC_Localization_Core
             }
             
             return values.ToArray();
-        }
-
-        private string TranslateWithRegex(string text, Dictionary<string, string> translations)
-        {
-            Match match = regexPattern.Match(text);
-            if (!match.Success)
-                return null;
-            
-            string result = TranslatedTemplate;
-            
-            // Replace {0}, {1}, {2} with captured groups
-            for (int i = 1; i < match.Groups.Count; i++)
-            {
-                result = result.Replace("{" + (i - 1) + "}", match.Groups[i].Value);
-            }
-            
-            // Replace {KEYNAME} with translations (e.g., {PRICETOTAL})
-            foreach (Match keyMatch in Regex.Matches(result, @"\{([A-Z]+)\}"))
-            {
-                string key = keyMatch.Groups[1].Value;
-                if (translations.TryGetValue(key, out string translation))
-                {
-                    result = result.Replace("{" + key + "}", translation);
-                }
-            }
-            
-            return result;
-        }
-
-        private string TranslateCommaSeparated(string text, Dictionary<string, string> translations)
-        {
-            string[] words = text.Split(',');
-            
-            for (int i = 0; i < words.Length; i++)
-            {
-                string word = words[i].Trim();
-                string key = MLCUtils.FormatUpperKey(word);
-                
-                if (translations.TryGetValue(key, out string translation))
-                {
-                    words[i] = translation;
-                }
-                else
-                {
-                    words[i] = word;
-                }
-            }
-            
-            return string.Join(", ", words);
         }
     }
 }

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -1,4 +1,3 @@
-using MSCLoader;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -73,7 +72,6 @@ namespace MWC_Localization_Core
         
         // Instance-based storage (supports multiple TextMeshes per path)
         private Dictionary<int, TextMeshEntry> instanceEntries;  // instanceID -> entry
-        private Dictionary<string, HashSet<int>> pathToInstances;  // path -> instanceIDs
         private Dictionary<MonitoringStrategy, HashSet<int>> strategyGroups;  // strategy -> instanceIDs
         private HashSet<string> monitoredPaths = new HashSet<string>();
         private List<int> removalBuffer = new List<int>(64);
@@ -84,7 +82,6 @@ namespace MWC_Localization_Core
             this.translator = translator;
             pathRules = new Dictionary<string, MonitoringStrategy>();
             instanceEntries = new Dictionary<int, TextMeshEntry>();
-            pathToInstances = new Dictionary<string, HashSet<int>>();
             strategyGroups = new Dictionary<MonitoringStrategy, HashSet<int>>();
 
             // Initialize strategy groups
@@ -142,8 +139,6 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/ServiceBrochure", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/ServicePayment", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/TrafficTicket", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyResults", MonitoringStrategy.OnVisibilityChange);
-            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("COMPUTER/SYSTEM/TELEBBS/CONLINE/CommandLine", MonitoringStrategy.OnVisibilityChange);
 
             // Magazine / Sheets - persistent monitoring due to dynamic content changes and rebuilds
@@ -151,6 +146,8 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyResults", MonitoringStrategy.Persistent);
+            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.Persistent);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
@@ -281,7 +278,7 @@ namespace MWC_Localization_Core
                     continue;
 
                 // Translate first to reduce visible unlocalized text
-                bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath, null);
+                bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath);
 
                 TextMeshEntry entry = new TextMeshEntry(textMesh, textMeshPath, finalStrategy);
                 if (translated)
@@ -290,17 +287,14 @@ namespace MWC_Localization_Core
                     entry.UpdateLastText();
                 }
 
+                if (finalStrategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
+                {
+                    registeredCount++;
+                    continue;
+                }
+
                 // Register instance
                 instanceEntries[instanceID] = entry;
-                
-                // Index by path
-                HashSet<int> pathSet;
-                if (!pathToInstances.TryGetValue(textMeshPath, out pathSet))
-                {
-                    pathSet = new HashSet<int>();
-                    pathToInstances[textMeshPath] = pathSet;
-                }
-                pathSet.Add(instanceID);
                 
                 // Group by strategy
                 strategyGroups[finalStrategy].Add(instanceID);
@@ -322,15 +316,6 @@ namespace MWC_Localization_Core
             // Remove from strategy group
             strategyGroups[entry.Strategy].Remove(instanceID);
 
-            // Remove from path index
-            HashSet<int> pathSet;
-            if (pathToInstances.TryGetValue(entry.Path, out pathSet))
-            {
-                pathSet.Remove(instanceID);
-                if (pathSet.Count == 0)
-                    pathToInstances.Remove(entry.Path);
-            }
-            
             // Remove instance
             instanceEntries.Remove(instanceID);
         }
@@ -356,7 +341,6 @@ namespace MWC_Localization_Core
             slowPollingTimer += deltaTime;
             if (slowPollingTimer >= LocalizationConstants.SLOW_POLLING_INTERVAL)
             {
-                UpdateGroup(MonitoringStrategy.SlowPolling);
                 UpdateGroup(MonitoringStrategy.LateTranslateOnce);
                 MonitorLateRegister(); // Also check for late registrations
                 slowPollingTimer = 0f;
@@ -385,9 +369,13 @@ namespace MWC_Localization_Core
                 // Check validity first to avoid NullReferenceException on destroyed objects
                 if (!entry.IsValid())
                 {
-                    // Persistent strategy: Keep checking even if entry is not valid
-                    if (strategy != MonitoringStrategy.Persistent)
-                        removalBuffer.Add(instanceID);
+                    removalBuffer.Add(instanceID);
+                    continue;
+                }
+
+                if (strategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
+                {
+                    removalBuffer.Add(instanceID);
                     continue;
                 }
 
@@ -400,14 +388,14 @@ namespace MWC_Localization_Core
                 
                 if (textChanged || !entry.WasTranslated)
                 {
-                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
+                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
                     if (translated)
                     {
                         entry.WasTranslated = true;
                         entry.UpdateLastText();
 
-                        // Mark for removal if TranslateOnce
-                        if (strategy == MonitoringStrategy.TranslateOnce || strategy == MonitoringStrategy.LateTranslateOnce)
+                        // Late one-shot entries can stop monitoring after the first successful translation.
+                        if (strategy == MonitoringStrategy.LateTranslateOnce)
                         {
                             removalBuffer.Add(instanceID);
                         }
@@ -425,6 +413,7 @@ namespace MWC_Localization_Core
         private void UpdateVisibilityChangeGroup()
         {
             var instanceIDs = strategyGroups[MonitoringStrategy.OnVisibilityChange];
+            removalBuffer.Clear();
 
             foreach (int instanceID in instanceIDs)
             {
@@ -433,7 +422,10 @@ namespace MWC_Localization_Core
                     continue;
 
                 if (!entry.IsValid())
+                {
+                    removalBuffer.Add(instanceID);
                     continue;
+                }
 
                 bool wasVisible = entry.IsVisible;
                 entry.UpdateVisibility();
@@ -441,13 +433,18 @@ namespace MWC_Localization_Core
                 // Only translate when visibility changes from hidden to visible
                 if (!wasVisible && entry.IsVisible)
                 {
-                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path, null);
+                    bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
                     if (translated)
                     {
                         entry.WasTranslated = true;
                         entry.UpdateLastText();
                     }
                 }
+            }
+
+            foreach (int instanceID in removalBuffer)
+            {
+                UnregisterInstance(instanceID);
             }
         }
 
@@ -461,7 +458,6 @@ namespace MWC_Localization_Core
                 group.Clear();
             }
             instanceEntries.Clear();
-            pathToInstances.Clear();
             pathRules.Clear();
             monitoredPaths.Clear();
             fastPollingTimer = 0f;

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -142,14 +142,14 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/ServicePayment", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("Sheets/TrafficTicket", MonitoringStrategy.OnVisibilityChange);
             AddPathRule("COMPUTER/SYSTEM/TELEBBS/CONLINE/CommandLine", MonitoringStrategy.OnVisibilityChange);
+            AddPathRule("Sheets/RallyResults", MonitoringStrategy.OnVisibilityChange);
+            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.OnVisibilityChange);
 
             // Magazine / Sheets - persistent monitoring due to dynamic content changes and rebuilds
             AddPathRule("Sheets/YellowPagesMagazine/Page1", MonitoringStrategy.Persistent);
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
-            AddPathRule("Sheets/RallyResults", MonitoringStrategy.Persistent);
-            AddPathRule("Sheets/RallyRegistration/Functions/Class", MonitoringStrategy.Persistent);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
@@ -184,12 +184,15 @@ namespace MWC_Localization_Core
                 int registered = Register(parentPath, strategy);
 
                 // Only queue for late retry if the initial Register couldn't find the parent yet
-                // (registered == 0). Persistent still stays queued so rebuilt children get picked up.
+                // (registered == 0). Persistent and OnVisibilityChange stay queued so rebuilt
+                // children get picked up.
                 bool needsLateQueue = strategy == MonitoringStrategy.LateTranslateOnce ||
                                       strategy == MonitoringStrategy.LateApplyFontOnce ||
                                       strategy == MonitoringStrategy.OnVisibilityChange ||
                                       strategy == MonitoringStrategy.Persistent;
-                if (needsLateQueue && (registered == 0 || strategy == MonitoringStrategy.Persistent))
+                if (needsLateQueue && (registered == 0 ||
+                                       strategy == MonitoringStrategy.Persistent ||
+                                       strategy == MonitoringStrategy.OnVisibilityChange))
                 {
                     monitoredPaths.Add(parentPath);
                 }
@@ -211,8 +214,11 @@ namespace MWC_Localization_Core
                 int registered = Register(parentPath, strategy);
 
                 // Remove from monitoring list if successfully registered.
-                // Persistent paths stay in the scan because their child TextMeshes can be rebuilt.
-                if (registered > 0 && strategy != MonitoringStrategy.Persistent)
+                // Persistent and OnVisibilityChange paths stay in the scan because their
+                // child TextMeshes can be rebuilt.
+                if (registered > 0 &&
+                    strategy != MonitoringStrategy.Persistent &&
+                    strategy != MonitoringStrategy.OnVisibilityChange)
                 {
                     stringRemovalBuffer.Add(parentPath);
                 }

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -13,6 +13,7 @@ namespace MWC_Localization_Core
         public string Path;
         public MonitoringStrategy Strategy;
         public string LastText;
+        public bool HasProcessedText;
         public bool WasTranslated;
         public bool IsVisible;
 
@@ -23,6 +24,7 @@ namespace MWC_Localization_Core
             Path = path;
             Strategy = strategy;
             LastText = textMesh != null ? textMesh.text : "";
+            HasProcessedText = false;
             WasTranslated = false;
             IsVisible = GameObject != null && GameObject.activeInHierarchy;
         }
@@ -281,10 +283,11 @@ namespace MWC_Localization_Core
                 bool translated = translator.TranslateAndApplyFont(textMesh, textMeshPath);
 
                 TextMeshEntry entry = new TextMeshEntry(textMesh, textMeshPath, finalStrategy);
+                entry.HasProcessedText = true;
+                entry.UpdateLastText();
                 if (translated)
                 {
                     entry.WasTranslated = true;
-                    entry.UpdateLastText();
                 }
 
                 if (finalStrategy == MonitoringStrategy.LateTranslateOnce && entry.WasTranslated)
@@ -385,14 +388,19 @@ namespace MWC_Localization_Core
                     continue;
 
                 bool textChanged = entry.HasTextChanged();
+                if (textChanged)
+                {
+                    entry.HasProcessedText = false;
+                }
                 
-                if (textChanged || !entry.WasTranslated)
+                if (textChanged || !entry.HasProcessedText)
                 {
                     bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
+                    entry.HasProcessedText = true;
+                    entry.UpdateLastText();
                     if (translated)
                     {
                         entry.WasTranslated = true;
-                        entry.UpdateLastText();
 
                         // Late one-shot entries can stop monitoring after the first successful translation.
                         if (strategy == MonitoringStrategy.LateTranslateOnce)
@@ -434,10 +442,11 @@ namespace MWC_Localization_Core
                 if (!wasVisible && entry.IsVisible)
                 {
                     bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
+                    entry.HasProcessedText = true;
+                    entry.UpdateLastText();
                     if (translated)
                     {
                         entry.WasTranslated = true;
-                        entry.UpdateLastText();
                     }
                 }
             }


### PR DESCRIPTION
- Removed unused modes/routes: RegexExtract, CommaSeparated, TranslateOnce, SlowPolling, dead PatternMatcher APIs, and TranslateMultilineByLines
- Removed duplicate magazine pattern handling in PatternMatcher.cs (now handled by MagazineTextHandler)
- Removed safe dead code: TranslationMode.SimpleLookup, TranslationPattern.Name, translationParts, translatedTextMeshes parameter, previousScene field

- Optimized scene translation in MWC_Localization_Core.cs: translation and forced font application now run in a single TextMesh pass, eliminating a second global sweep
- Factored duplicated GAME scene initialization flow into InitializeGameDataSources
- Reduced overhead in UnifiedTextMeshMonitor.cs by removing the unused pathToInstances index

- Improved UnifiedTextMeshMonitor lifecycle: removes invalid entries in Persistent and OnVisibilityChange, excludes LateTranslateOnce entries translated in Register() from monitoring groups, and cleans up LateTranslateOnce entries marked as WasTranslated in UpdateGroup()

- Improved stability in TextMeshTranslator.cs: caches renderer.material per renderer only when non-null, updates appliedRuntimeTextureCache only with valid materials, avoids repeated material instantiation, and performs direct lookup before pattern matching for common texts (magazine remains prioritized)

- Replaced GameObject.Find (menu) with MLCUtils.FindGameObjectCached

- Unified key normalization: replaced ToUpperInvariant() with MLCUtils.FormatUpperKey() for consistent lookup, aligned TeletextHandler lookup with parser behavior, and eliminated mismatches from inconsistent formatting

- Centralized category key normalization in TranslationFileParser.cs and applied it across ParseCategoryBasedFile(), SaveEntry(), and TeletextHandler.cs to remove duplicated normalization rules

- Fixed CustomHandler in TranslationPattern.cs, restoring PCMultiLine execution

- Optimized TeletextHandler: rewrites/counts entries only when text actually changes, reducing redundant work in dynamic chat scenarios

- Changed monitoring strategy from OnVisibilityChange to Persistent for Sheets/RallyResults and Sheets/RallyRegistration/Functions/Class, fixing missed translations when opening sheets rapidly or repeatedly

- Ensured magazineHandler.HandleMagazineText(textMesh) always executes for side effects and marks entries as handled, while HasTextChanged() still allows reprocessing on dynamic updates

Monitored by chatGPT 5.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated initialization and streamlined translation pipeline for improved reliability and responsiveness
  * Introduced runtime material caching to reduce overhead and improve font/texture application
  * Simplified monitoring behavior and removed several legacy translation modes and pattern APIs

* **Bug Fixes**
  * More reliable menu/scene FSM discovery and more consistent translation counting to avoid unnecessary overwrites
  * Polling/timing adjusted for faster updates

* **Chores**
  * Removed unused imports and miscellaneous cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->