### PR TITLE
Fix text adjustment handling and magazine product layout

### DIFF
--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -24,6 +24,12 @@ namespace MWC_Localization_Core
         Persistent,
 
         /// <summary>
+        /// Keep font and layout adjustments enforced for content whose transform is rebuilt by the game.
+        /// Use only for small, known text groups.
+        /// </summary>
+        PersistentLayout,
+
+        /// <summary>
         /// Translate only when a GameObject becomes active in the hierarchy.
         /// Use for menus, dialogs, and other show/hide UI panels.
         /// </summary>

--- a/TextAdjustment.cs
+++ b/TextAdjustment.cs
@@ -40,6 +40,13 @@ namespace MWC_Localization_Core
         // Store original state of adjusted TextMesh objects for restoration
         private Dictionary<TextMesh, OriginalTextMeshState> originalStates = new Dictionary<TextMesh, OriginalTextMeshState>();
 
+        // Last values written by this rule. If the game rewrites a transform later,
+        // the next monitor tick can apply the offset again without accumulating it.
+        private Dictionary<TextMesh, Vector3> lastAppliedLocalPositions = new Dictionary<TextMesh, Vector3>();
+        // PositionToleranceSqr is a squared Vector3.sqrMagnitude threshold, not a raw
+        // distance; 1e-7 means about 3.16e-4 units of linear drift.
+        private const float PositionToleranceSqr = 0.0000001f;
+
         public TextAdjustment(string conditionsString, Vector3 offset, float? fontSize = null, float? lineSpacing = null, float? widthScale = null)
         {
             Offset = offset;
@@ -59,17 +66,33 @@ namespace MWC_Localization_Core
             if (textMesh == null)
                 return false;
 
-            // Skip if already adjusted
-            if (adjustedTextMeshes.Contains(textMesh))
-                return false;
+            bool alreadyAdjusted = adjustedTextMeshes.Contains(textMesh);
 
             // Store original state before applying adjustments (only once, on first application)
             if (!originalStates.ContainsKey(textMesh))
                 originalStates[textMesh] = new OriginalTextMeshState(textMesh);
 
+            if (alreadyAdjusted)
+            {
+                Vector3 lastAppliedPosition;
+                if (lastAppliedLocalPositions.TryGetValue(textMesh, out lastAppliedPosition))
+                {
+                    Vector3 positionDelta = textMesh.transform.localPosition - lastAppliedPosition;
+                    if (positionDelta.sqrMagnitude <= PositionToleranceSqr)
+                        return false;
+                }
+
+                // The game moved this TextMesh after our last adjustment. Keep the
+                // original sizing values, but use the current transform as the new base.
+                OriginalTextMeshState updatedState = originalStates[textMesh];
+                updatedState.LocalPosition = textMesh.transform.localPosition;
+                originalStates[textMesh] = updatedState;
+            }
+
             // Apply the position offset
-            Vector3 currentPosition = textMesh.transform.localPosition;
-            textMesh.transform.localPosition = currentPosition + Offset;
+            OriginalTextMeshState originalState = originalStates[textMesh];
+            Vector3 targetPosition = originalState.LocalPosition + Offset;
+            textMesh.transform.localPosition = targetPosition;
 
             // Apply font size if specified
             if (FontSize.HasValue)
@@ -96,6 +119,7 @@ namespace MWC_Localization_Core
 
             // Mark as adjusted
             adjustedTextMeshes.Add(textMesh);
+            lastAppliedLocalPositions[textMesh] = targetPosition;
 
             return true;
         }
@@ -122,6 +146,7 @@ namespace MWC_Localization_Core
 
             // Remove from adjusted set so it can be re-adjusted
             adjustedTextMeshes.Remove(textMesh);
+            lastAppliedLocalPositions.Remove(textMesh);
 
             return true;
         }
@@ -140,6 +165,7 @@ namespace MWC_Localization_Core
             }
             // adjustedTextMeshes is already cleared by RestoreOriginal() calls
             originalStates.Clear();
+            lastAppliedLocalPositions.Clear();
         }
 
         /// <summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -190,9 +190,13 @@ namespace MWC_Localization_Core
             if (!translations.TryGetValue(normalizedKey, out string translation))
                 return false;
 
-            // Skip translation if already translated (unless forced)
+            // If the text already equals its mapped value, still apply font/adjustments
+            // and report it as handled so one-shot monitors can stop cleanly.
             if (!forceUpdate && currentText == translation)
-                return false;
+            {
+                ApplyCustomFont(textMesh, path);
+                return true;
+            }
 
             // Apply custom font first
             ApplyCustomFont(textMesh, path);

--- a/TranslationFileParser.cs
+++ b/TranslationFileParser.cs
@@ -85,15 +85,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Unescape special characters: \= -> =, \n -> newline
-        /// Public utility for other components
-        /// </summary>
-        public static string UnescapeValue(string input)
-        {
-            return UnescapeString(input);
-        }
-
-        /// <summary>
         /// Find the index of the first unescaped '=' character
         /// Returns -1 if no unescaped '=' is found
         /// </summary>

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -76,6 +76,7 @@ namespace MWC_Localization_Core
         private Dictionary<int, TextMeshEntry> instanceEntries;  // instanceID -> entry
         private Dictionary<MonitoringStrategy, HashSet<int>> strategyGroups;  // strategy -> instanceIDs
         private HashSet<string> monitoredPaths = new HashSet<string>();
+        private HashSet<string> persistentLayoutPaths = new HashSet<string>();
         private List<int> removalBuffer = new List<int>(64);
         private List<string> stringRemovalBuffer = new List<string>(16);
 
@@ -150,11 +151,18 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
+
+            // Magazine Products / Sheets - persistent layout monitoring due to dynamic content changes and rebuilds
+            AddPathRule("Sheets/Magazine/Products", MonitoringStrategy.PersistentLayout);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
         {
             pathRules[pathPattern] = strategy;
+            if (strategy == MonitoringStrategy.PersistentLayout)
+                persistentLayoutPaths.Add(pathPattern);
+            else
+                persistentLayoutPaths.Remove(pathPattern);
         }
 
         // A parent scan (e.g. FastPolling on "CHAT/Day") must not absorb TextMeshes that have
@@ -186,15 +194,15 @@ namespace MWC_Localization_Core
                 // Only queue for late retry if the initial Register couldn't find the parent yet
                 // (registered == 0). Persistent and OnVisibilityChange stay queued so rebuilt
                 // children get picked up.
+                bool keepQueued = strategy == MonitoringStrategy.OnVisibilityChange ||
+                                  strategy == MonitoringStrategy.Persistent ||
+                                  strategy == MonitoringStrategy.PersistentLayout;
                 bool needsLateQueue = strategy == MonitoringStrategy.LateTranslateOnce ||
                                       strategy == MonitoringStrategy.LateApplyFontOnce ||
-                                      strategy == MonitoringStrategy.OnVisibilityChange ||
-                                      strategy == MonitoringStrategy.Persistent;
-                if (needsLateQueue && (registered == 0 ||
-                                       strategy == MonitoringStrategy.Persistent ||
-                                       strategy == MonitoringStrategy.OnVisibilityChange))
+                                      keepQueued;
+                if (needsLateQueue && (registered == 0 || keepQueued))
                 {
-                    monitoredPaths.Add(parentPath);
+                    AddMonitoredPath(parentPath, strategy);
                 }
             }
         }
@@ -202,14 +210,21 @@ namespace MWC_Localization_Core
         /// <summary>
         /// Periodically monitor TextMeshes to be available for monitoring
         /// </summary>
-        public void MonitorLateRegister()
+        public void MonitorLateRegister(MonitoringStrategy? strategyFilter = null)
         {
             stringRemovalBuffer.Clear();
-            foreach (string parentPath in monitoredPaths)
+            HashSet<string> pathsToScan = strategyFilter.HasValue && strategyFilter.Value == MonitoringStrategy.PersistentLayout
+                ? persistentLayoutPaths
+                : monitoredPaths;
+
+            foreach (string parentPath in pathsToScan)
             {
                 MonitoringStrategy strategy;
                 if (!pathRules.TryGetValue(parentPath, out strategy))
                     strategy = MonitoringStrategy.LateTranslateOnce;
+
+                if (strategyFilter.HasValue && strategy != strategyFilter.Value)
+                    continue;
 
                 int registered = Register(parentPath, strategy);
 
@@ -218,6 +233,7 @@ namespace MWC_Localization_Core
                 // child TextMeshes can be rebuilt.
                 if (registered > 0 &&
                     strategy != MonitoringStrategy.Persistent &&
+                    strategy != MonitoringStrategy.PersistentLayout &&
                     strategy != MonitoringStrategy.OnVisibilityChange)
                 {
                     stringRemovalBuffer.Add(parentPath);
@@ -225,8 +241,21 @@ namespace MWC_Localization_Core
             }
             for (int i = 0; i < stringRemovalBuffer.Count; i++)
             {
-                monitoredPaths.Remove(stringRemovalBuffer[i]);
+                RemoveMonitoredPath(stringRemovalBuffer[i]);
             }
+        }
+
+        private void AddMonitoredPath(string parentPath, MonitoringStrategy strategy)
+        {
+            monitoredPaths.Add(parentPath);
+            if (strategy == MonitoringStrategy.PersistentLayout)
+                persistentLayoutPaths.Add(parentPath);
+        }
+
+        private void RemoveMonitoredPath(string parentPath)
+        {
+            monitoredPaths.Remove(parentPath);
+            persistentLayoutPaths.Remove(parentPath);
         }
 
         /// <summary>
@@ -337,6 +366,11 @@ namespace MWC_Localization_Core
             // Always update EveryFrame
             UpdateGroup(MonitoringStrategy.EveryFrame);
 
+            // Layout-sensitive magazine text can be rebuilt while the sheet is opened,
+            // so keep it registered and adjusted in the same LateUpdate pass.
+            MonitorLateRegister(MonitoringStrategy.PersistentLayout);
+            UpdateGroup(MonitoringStrategy.PersistentLayout);
+
             // Throttled fast polling (0.1s)
             fastPollingTimer += deltaTime;
             if (fastPollingTimer >= LocalizationConstants.FAST_POLLING_INTERVAL)
@@ -399,6 +433,11 @@ namespace MWC_Localization_Core
                     entry.HasProcessedText = false;
                 }
                 
+                if (strategy == MonitoringStrategy.PersistentLayout)
+                {
+                    translator.ApplyFontOnly(entry.TextMesh, entry.Path);
+                }
+
                 if (textChanged || !entry.HasProcessedText)
                 {
                     bool translated = translator.TranslateAndApplyFont(entry.TextMesh, entry.Path);
@@ -475,6 +514,7 @@ namespace MWC_Localization_Core
             instanceEntries.Clear();
             pathRules.Clear();
             monitoredPaths.Clear();
+            persistentLayoutPaths.Clear();
             fastPollingTimer = 0f;
             slowPollingTimer = 0f;
             visibilityPollingTimer = 0f;


### PR DESCRIPTION
* The dead method UnescapeValue has been removed.
* Apply font/adjustments after the text has already been processed.
* fix: keep magazine product text layout adjusted

- Add a PersistentLayout monitoring strategy for the magazine product list so font and position adjustments are enforced in LateUpdate while the sheet is being rebuilt.

- Track the last adjusted TextMesh position and reapply offsets when the game rewrites the transform, without accumulating the configured offset on every tick. This fixes the product list appearing briefly in the wrong position before settling into the configured adjustment.

* fix: keep magazine product layout stable

- Add a PersistentLayout strategy for the magazine product list so its font and position adjustments stay enforced while the game rebuilds the sheet text.

- Reapply position offsets only when the game has moved a TextMesh since the last adjustment, avoiding accumulated offsets while keeping the configured layout stable. Limit per-frame late registration to PersistentLayout paths through a dedicated path set, so the layout fix does not scan all monitored paths every frame.

* fix: preserve text adjustment original state

Update moved TextMesh handling to preserve the original size, line spacing, and width scale while refreshing only the base local position before reapplying offsets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for persistent layout text monitoring to improve handling of UI elements with static transforms.

* **Bug Fixes**
  * Fixed text adjustment drift when TextMesh transforms are modified during gameplay.
  * Improved font customization preservation for already-translated text.
  * Enhanced adjustment restoration accuracy and prevented cumulative adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->