### PR TITLE
feat: implement drift tracking for TextMeshes

### DIFF
--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -229,11 +229,23 @@ namespace MWC_Localization_Core
             {
                 if (adjustment.Matches(path))
                 {
-                    return adjustment.ApplyAdjustment(textMesh);
+                    return adjustment.ApplyAdjustment(textMesh, path);
                 }
             }
 
             return false; // No matching adjustment found
+        }
+
+        /// <summary>
+        /// Re-pin drift-tracked TextMeshes whose transform was rewritten by the game
+        /// since the last frame. Called every LateUpdate by the monitor.
+        /// </summary>
+        public void RefreshDriftTrackedAdjustments()
+        {
+            foreach (TextAdjustment adjustment in TextAdjustments)
+            {
+                adjustment.Refresh();
+            }
         }
 
         /// <summary>

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -24,6 +24,16 @@ namespace MWC_Localization_Core
         Persistent,
 
         /// <summary>
+        /// Like Persistent, but the parent itself rebuilds child GameObjects while the
+        /// screen is open (e.g. magazine sheets). The parent's subtree is re-scanned 
+        /// every LateUpdate so new child TextMeshes are translated and adjusted 
+        /// on the same frame they appear. Pair with TextAdjustment.DriftTrackedPathPatterns
+        /// when the rebuilt transforms also need their position offset re-pinned.
+        /// Every entry pays a per-frame GetComponentsInChildren walk - use sparingly.
+        /// </summary>
+        PersistentRebuilding,
+
+        /// <summary>
         /// Translate only when a GameObject becomes active in the hierarchy.
         /// Use for menus, dialogs, and other show/hide UI panels.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ X,Y,Z[,FontSize,LineSpacing,WidthScale]
 - Use `WidthScale < 1.0` to make text narrower (good for condensed layouts)
 - Combine with FontSize to control both height and width independently
 
+### Drift-tracked paths
+
+A few sheets (e.g. `Sheets/Magazine/Products`) are rebuilt by the game while the screen is open, which would normally let the rebuilt transform overwrite the position offset. These paths are listed in a small in-code whitelist (`TextAdjustment.DriftTrackedPathPatterns`) and re-pinned every frame. Adding a path to the whitelist is a code change, not a config change — open an issue if you find another sheet that flickers.
+
 ## Creating Custom Fonts (Optional)
 
 For languages requiring special font support (better readability, special characters, etc.):

--- a/TextAdjustment.cs
+++ b/TextAdjustment.cs
@@ -28,6 +28,29 @@ namespace MWC_Localization_Core
     /// </summary>
     public class TextAdjustment
     {
+        // Paths whose transforms the game rewrites repeatedly (e.g. magazine sheets that
+        // get rebuilt while open). TextMeshes whose path matches any entry get drift-
+        // tracked and re-pinned every LateUpdate. Keep this list small - every entry
+        // pays a per-frame cost proportional to the number of TextMeshes it has touched.
+        private static readonly string[] DriftTrackedPathPatterns =
+        {
+            "Sheets/Magazine/Products",
+        };
+
+        private const float PositionToleranceSqr = 1e-7f;
+
+        private static bool IsDriftTracked(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return false;
+            for (int i = 0; i < DriftTrackedPathPatterns.Length; i++)
+            {
+                if (path.Contains(DriftTrackedPathPatterns[i]))
+                    return true;
+            }
+            return false;
+        }
+
         public List<PathCondition> Conditions { get; private set; } = new List<PathCondition>();
         public Vector3 Offset { get; private set; }
         public float? FontSize { get; private set; }
@@ -39,6 +62,10 @@ namespace MWC_Localization_Core
 
         // Store original state of adjusted TextMesh objects for restoration
         private Dictionary<TextMesh, OriginalTextMeshState> originalStates = new Dictionary<TextMesh, OriginalTextMeshState>();
+
+        // Last position written by this rule, for drift-tracked TextMeshes only.
+        // Presence in this dict is the marker that a mesh participates in Refresh().
+        private Dictionary<TextMesh, Vector3> lastAppliedLocalPositions = new Dictionary<TextMesh, Vector3>();
 
         public TextAdjustment(string conditionsString, Vector3 offset, float? fontSize = null, float? lineSpacing = null, float? widthScale = null)
         {
@@ -54,7 +81,7 @@ namespace MWC_Localization_Core
         /// Uses HashSet to prevent duplicate adjustments
         /// </summary>
         /// <returns>True if adjustment was applied, false if already adjusted</returns>
-        public bool ApplyAdjustment(TextMesh textMesh)
+        public bool ApplyAdjustment(TextMesh textMesh, string path)
         {
             if (textMesh == null)
                 return false;
@@ -69,7 +96,8 @@ namespace MWC_Localization_Core
 
             // Apply the position offset
             Vector3 currentPosition = textMesh.transform.localPosition;
-            textMesh.transform.localPosition = currentPosition + Offset;
+            Vector3 newPosition = currentPosition + Offset;
+            textMesh.transform.localPosition = newPosition;
 
             // Apply font size if specified
             if (FontSize.HasValue)
@@ -97,7 +125,61 @@ namespace MWC_Localization_Core
             // Mark as adjusted
             adjustedTextMeshes.Add(textMesh);
 
+            // Opt this mesh into Refresh() only if its path is on the drift-tracked whitelist.
+            if (IsDriftTracked(path))
+                lastAppliedLocalPositions[textMesh] = newPosition;
+
             return true;
+        }
+
+        /// <summary>
+        /// Re-pin drift-tracked TextMeshes whose local position the game has rewritten
+        /// since the last frame. Caller invokes every LateUpdate. No-op when nothing is tracked.
+        /// </summary>
+        public void Refresh()
+        {
+            if (lastAppliedLocalPositions.Count == 0)
+                return;
+
+            List<TextMesh> stale = null;
+            // Snapshot keys - we mutate the dict on hits.
+            foreach (TextMesh tm in new List<TextMesh>(lastAppliedLocalPositions.Keys))
+            {
+                if (tm == null)
+                {
+                    if (stale == null) stale = new List<TextMesh>();
+                    stale.Add(tm);
+                    continue;
+                }
+
+                Vector3 currentPos = tm.transform.localPosition;
+                Vector3 lastApplied = lastAppliedLocalPositions[tm];
+                if ((currentPos - lastApplied).sqrMagnitude <= PositionToleranceSqr)
+                    continue;
+
+                // Game wrote a new local position. Treat it as the new baseline so we
+                // don't accumulate drift, then re-apply the offset.
+                OriginalTextMeshState state;
+                if (originalStates.TryGetValue(tm, out state))
+                {
+                    state.LocalPosition = currentPos;
+                    originalStates[tm] = state;
+                }
+
+                Vector3 newPos = currentPos + Offset;
+                tm.transform.localPosition = newPos;
+                lastAppliedLocalPositions[tm] = newPos;
+            }
+
+            if (stale != null)
+            {
+                for (int i = 0; i < stale.Count; i++)
+                {
+                    lastAppliedLocalPositions.Remove(stale[i]);
+                    originalStates.Remove(stale[i]);
+                    adjustedTextMeshes.Remove(stale[i]);
+                }
+            }
         }
 
         /// <summary>
@@ -122,6 +204,7 @@ namespace MWC_Localization_Core
 
             // Remove from adjusted set so it can be re-adjusted
             adjustedTextMeshes.Remove(textMesh);
+            lastAppliedLocalPositions.Remove(textMesh);
 
             return true;
         }
@@ -140,6 +223,7 @@ namespace MWC_Localization_Core
             }
             // adjustedTextMeshes is already cleared by RestoreOriginal() calls
             originalStates.Clear();
+            lastAppliedLocalPositions.Clear();
         }
 
         /// <summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -190,9 +190,14 @@ namespace MWC_Localization_Core
             if (!translations.TryGetValue(normalizedKey, out string translation))
                 return false;
 
-            // Skip translation if already translated (unless forced)
+            // Already-localized text still needs its font + adjustments applied so
+            // one-shot monitors can stop cleanly and so drift-tracked meshes get
+            // entered into lastAppliedLocalPositions on first contact.
             if (!forceUpdate && currentText == translation)
-                return false;
+            {
+                ApplyCustomFont(textMesh, path);
+                return true;
+            }
 
             // Apply custom font first
             ApplyCustomFont(textMesh, path);
@@ -232,6 +237,15 @@ namespace MWC_Localization_Core
             return beforeFontName != afterFontName;
         }
         
+        /// <summary>
+        /// Re-pin drift-tracked TextMeshes (e.g. magazine sheets the game rebuilds).
+        /// Called every LateUpdate by the monitor.
+        /// </summary>
+        public void RefreshDriftTrackedAdjustments()
+        {
+            config.RefreshDriftTrackedAdjustments();
+        }
+
         /// <summary>
         /// Load FSM patterns from teletext translation file
         /// </summary>

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -76,6 +76,11 @@ namespace MWC_Localization_Core
         private Dictionary<int, TextMeshEntry> instanceEntries;  // instanceID -> entry
         private Dictionary<MonitoringStrategy, HashSet<int>> strategyGroups;  // strategy -> instanceIDs
         private HashSet<string> monitoredPaths = new HashSet<string>();
+        // Subset of pathRules whose strategy is PersistentRebuilding. Re-scanned every
+        // frame so newly-spawned child TextMeshes are picked up the same frame they
+        // appear. Kept small on purpose - every entry pays a per-frame
+        // GetComponentsInChildren walk.
+        private HashSet<string> rebuildingPaths = new HashSet<string>();
         private List<int> removalBuffer = new List<int>(64);
         private List<string> stringRemovalBuffer = new List<string>(16);
 
@@ -150,11 +155,16 @@ namespace MWC_Localization_Core
             AddPathRule("Sheets/YellowPagesMagazine/Page2", MonitoringStrategy.Persistent);
             AddPathRule("PERAPORTTI/ActiveFunctions/ATMs/MoneyATM/Screen/Tapahtumat", MonitoringStrategy.Persistent);
             AddPathRule("COMPUTER/SYSTEM/POS/NoOS", MonitoringStrategy.Persistent);
+
+            // Magazine product list - parent rebuilds children while sheet is open.
+            AddPathRule("Sheets/Magazine/Products", MonitoringStrategy.PersistentRebuilding);
         }
 
         public void AddPathRule(string pathPattern, MonitoringStrategy strategy)
         {
             pathRules[pathPattern] = strategy;
+            if (strategy == MonitoringStrategy.PersistentRebuilding)
+                rebuildingPaths.Add(pathPattern);
         }
 
         // A parent scan (e.g. FastPolling on "CHAT/Day") must not absorb TextMeshes that have
@@ -330,10 +340,32 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Re-run Register() for PersistentRebuilding parents so newly-spawned child
+        /// TextMeshes are picked up the same frame they appear. Register() already
+        /// deduplicates by instanceID; the dominant cost is one
+        /// GetComponentsInChildren&lt;TextMesh&gt;(true) per parent, so rebuildingPaths
+        /// must stay tiny.
+        /// </summary>
+        private void ScanRebuildingPaths()
+        {
+            foreach (string parentPath in rebuildingPaths)
+            {
+                Register(parentPath, MonitoringStrategy.PersistentRebuilding);
+            }
+        }
+
+        /// <summary>
         /// Main update loop - called every frame
         /// </summary>
         public void Update(float deltaTime)
         {
+            // Per-frame work for content the game rebuilds in place.
+            // ScanRebuildingPaths catches new child TextMeshes; the translator's
+            // drift-tracked refresh re-pins meshes whose transforms the game rewrites
+            // every frame. Both lists are deliberately tiny.
+            ScanRebuildingPaths();
+            translator.RefreshDriftTrackedAdjustments();
+
             // Always update EveryFrame
             UpdateGroup(MonitoringStrategy.EveryFrame);
 
@@ -343,6 +375,7 @@ namespace MWC_Localization_Core
             {
                 UpdateGroup(MonitoringStrategy.FastPolling);
                 UpdateGroup(MonitoringStrategy.Persistent);
+                UpdateGroup(MonitoringStrategy.PersistentRebuilding);
                 fastPollingTimer = 0f;
             }
 
@@ -475,6 +508,7 @@ namespace MWC_Localization_Core
             instanceEntries.Clear();
             pathRules.Clear();
             monitoredPaths.Clear();
+            rebuildingPaths.Clear();
             fastPollingTimer = 0f;
             slowPollingTimer = 0f;
             visibilityPollingTimer = 0f;


### PR DESCRIPTION
## Summary
Fixes the magazine product list (Sheets/Magazine/Products) losing its position adjustment and flickering when the game rebuilds TextMeshes while the sheet is open.

This is based on the approach from #72 (LucasMonFC, 781ad3d), which identified the root cause and introduced drift detection as the core fix. This PR ports those ideas to upstream with the concerns separated more cleanly:

## Changes from #72:

- The new strategy enum value is named PersistentRebuilding instead of PersistentLayout, and its scope is narrower: it only governs registration cadence (per-frame GetComponentsInChildren rescan to catch newly-spawned children), not layout re-pinning. The two concerns live in separate places.
- Drift re-pinning is opt-in via TextAdjustment.DriftTrackedPathPatterns, a small in-code whitelist. Only TextMeshes whose path matches an entry in that list are tracked in lastAppliedLocalPositions and visited by Refresh(). In #72 the drift check ran on all adjusted meshes; here the per-frame cost is proportional to the whitelist size, which is 1 entry today.
- Refresh() is called once per frame through LocalizationConfig → TextMeshTranslator → UnifiedTextMeshMonitor.Update(), bypassing the monitor's per-mesh scaffolding and the linear TextAdjustments scan on each text change.
- The already-localized early-return in ApplyTranslation is fixed to still apply font + adjustments and return true (so one-shot monitors stop cleanly and newly-registered drift-tracked meshes enter lastAppliedLocalPositions on first contact). This fix is also present in #72.

## What changed
- MonitoringStrategy.cs — New PersistentRebuilding value for parents that rebuild child GameObjects while a screen is open.
- TextAdjustment.cs — DriftTrackedPathPatterns whitelist + lastAppliedLocalPositions dict + Refresh() method. ApplyAdjustment signature gains a path parameter. RestoreOriginal and ClearCache clear the new dict.
- LocalizationConfig.cs — Forwards path to ApplyAdjustment; adds RefreshDriftTrackedAdjustments() hook.
- TextMeshTranslator.cs — Early-return fix in ApplyTranslation; RefreshDriftTrackedAdjustments() passthrough.
- UnifiedTextMeshMonitor.cs — rebuildingPaths HashSet populated by AddPathRule; ScanRebuildingPaths() called per frame; Sheets/Magazine/Products added as PersistentRebuilding; translator.RefreshDriftTrackedAdjustments() called per frame in Update().
- README.md — Documents that drift-tracked paths live in an in-code whitelist and that adding one is a code change, not a config change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for persistent rebuilding strategy to handle dynamically recreated UI elements during gameplay.
  * Text position adjustments now automatically re-pin each frame to prevent configured offsets from being overridden when UI elements are rebuilt.

* **Documentation**
  * Added documentation on drift-tracked text adjustment paths for managing game-rebuilt UI sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->