### PR TITLE
Improve localization runtime frametime stability

### DIFF
--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -20,10 +20,13 @@ namespace MWC_Localization_Core
         private HashSet<string> loggedReadyTargets = new HashSet<string>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
         private float lastEnnusteDataFsmScanTime = -10f;
+        private int unchangedMaintenanceTicks = 0;
 
         private static readonly WaitForSeconds BootstrapPollDelay = new WaitForSeconds(0.5f);
         private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(1.0f);
+        private static readonly WaitForSeconds SettledMaintenancePollDelay = new WaitForSeconds(3.0f);
         private const float EnnusteDataRescanInterval = 2f;
+        private const int SettledMaintenanceThreshold = 3;
 
         // Reflection cache: (Type, fieldName) -> FieldInfo to avoid repeated GetField calls
         private static readonly Dictionary<System.Type, Dictionary<string, FieldInfo>> reflectionCache
@@ -275,8 +278,19 @@ namespace MWC_Localization_Core
 
                 if (currentScene == "GAME")
                 {
-                    TryApplyGameTranslations();
-                    yield return MaintenancePollDelay;
+                    bool changed = TryApplyGameTranslations();
+                    if (changed)
+                    {
+                        unchangedMaintenanceTicks = 0;
+                    }
+                    else
+                    {
+                        unchangedMaintenanceTicks++;
+                    }
+
+                    yield return unchangedMaintenanceTicks >= SettledMaintenanceThreshold
+                        ? SettledMaintenancePollDelay
+                        : MaintenancePollDelay;
                     continue;
                 }
 
@@ -284,10 +298,10 @@ namespace MWC_Localization_Core
             }
         }
 
-        private void TryApplyGameTranslations()
+        private bool TryApplyGameTranslations()
         {
             if (translations == null)
-                return;
+                return false;
 
             bool anyChanged = false;
             anyChanged |= TryApplyGamePosFsmTranslations();
@@ -301,6 +315,8 @@ namespace MWC_Localization_Core
                 string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "GAME" : appliedTarget;
                 CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
             }
+
+            return anyChanged;
         }
 
         private bool TryApplyMainMenuTranslations()
@@ -347,7 +363,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME POS";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameTeletextBottomlineFsmTranslations()
@@ -361,7 +377,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Teletext Bottomline";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameTeletextWeatherUpdaterFsmTranslations()
@@ -387,7 +403,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Teletext Weather";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameUnemployPaperFsmTranslations()
@@ -402,7 +418,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME UnemployPaper";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameConlineChatFsmTranslations()
@@ -417,7 +433,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Conline Chat";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged, ref bool hasAnyTarget)

--- a/LocalizationConstants.cs
+++ b/LocalizationConstants.cs
@@ -10,6 +10,7 @@ namespace MWC_Localization_Core
         public const float FAST_POLLING_INTERVAL = 0.15f;           // ~6.6 times per second
         public const float SLOW_POLLING_INTERVAL = 1.0f;            // Once per second
         public const float VISIBILITY_POLLING_INTERVAL = 0.35f;     // ~3 times per second
+        public const float REBUILDING_SCAN_INTERVAL = 0.25f;        // Dynamic rebuilt UI scan cadence
         public const float ARRAY_MONITOR_INTERVAL = 2.0f;           // Check arrays every 2 seconds
     }
 }

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -112,17 +112,39 @@ namespace MWC_Localization_Core
 
             string cacheKey = objectPath + "|" + fsmName;
 
-            EnsureFsmIndexFresh();
-
             PlayMakerFSM cachedFsm;
-            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm)
-                && cachedFsm != null
-                && cachedFsm.gameObject != null)
+            if (TryGetCachedFsm(cacheKey, out cachedFsm))
             {
                 return cachedFsm;
             }
 
+            // Full inactive FSM scans are expensive. Build the index once, then only
+            // refresh on cache misses after a cooldown so optional/missing targets do
+            // not create a steady frametime spike.
+            if (!fsmIndexBuilt || IsFsmIndexStale())
+            {
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+                if (TryGetCachedFsm(cacheKey, out cachedFsm))
+                {
+                    return cachedFsm;
+                }
+            }
+
             return null;
+        }
+
+        private static bool TryGetCachedFsm(string cacheKey, out PlayMakerFSM cachedFsm)
+        {
+            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm))
+            {
+                if (cachedFsm != null && cachedFsm.gameObject != null)
+                    return true;
+
+                inactiveFsmPathNameCache.Remove(cacheKey);
+            }
+
+            cachedFsm = null;
+            return false;
         }
 
         /// <summary>
@@ -138,8 +160,29 @@ namespace MWC_Localization_Core
             if (string.IsNullOrEmpty(pathPrefix) || string.IsNullOrEmpty(fsmName))
                 return;
 
-            EnsureFsmIndexFresh();
+            EnsureFsmIndexBuilt();
+            AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);
 
+            if (results.Count == 0 && IsFsmIndexStale())
+            {
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+                AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);
+            }
+        }
+
+        private static bool IsFsmIndexStale()
+        {
+            return Time.realtimeSinceStartup - lastFsmIndexBuildTime >= FSM_INDEX_REFRESH_INTERVAL;
+        }
+
+        private static void EnsureFsmIndexBuilt()
+        {
+            if (!fsmIndexBuilt)
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+        }
+
+        private static void AddMatchingFsmsByPrefix(string pathPrefix, string fsmName, List<PlayMakerFSM> results)
+        {
             foreach (PlayMakerFSM fsm in inactiveFsmPathNameCache.Values)
             {
                 if (fsm == null || fsm.gameObject == null)
@@ -154,15 +197,6 @@ namespace MWC_Localization_Core
                     results.Add(fsm);
                 }
             }
-        }
-
-        private static void EnsureFsmIndexFresh()
-        {
-            float now = Time.realtimeSinceStartup;
-            if (fsmIndexBuilt && now - lastFsmIndexBuildTime < FSM_INDEX_REFRESH_INTERVAL)
-                return;
-
-            RebuildFsmIndex(now);
         }
 
         private static void RebuildFsmIndex(float timestamp)

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -68,6 +68,7 @@ namespace MWC_Localization_Core
         private float fastPollingTimer;
         private float slowPollingTimer;
         private float visibilityPollingTimer;
+        private float rebuildingScanTimer = LocalizationConstants.REBUILDING_SCAN_INTERVAL;
 
         // Path-based monitoring rules (pattern -> strategy mapping)
         private Dictionary<string, MonitoringStrategy> pathRules;
@@ -341,10 +342,10 @@ namespace MWC_Localization_Core
 
         /// <summary>
         /// Re-run Register() for PersistentRebuilding parents so newly-spawned child
-        /// TextMeshes are picked up the same frame they appear. Register() already
+        /// TextMeshes are picked up shortly after they appear. Register() already
         /// deduplicates by instanceID; the dominant cost is one
-        /// GetComponentsInChildren&lt;TextMesh&gt;(true) per parent, so rebuildingPaths
-        /// must stay tiny.
+        /// GetComponentsInChildren&lt;TextMesh&gt;(true) per parent, so this scan is
+        /// throttled instead of running every frame.
         /// </summary>
         private void ScanRebuildingPaths()
         {
@@ -359,11 +360,16 @@ namespace MWC_Localization_Core
         /// </summary>
         public void Update(float deltaTime)
         {
-            // Per-frame work for content the game rebuilds in place.
-            // ScanRebuildingPaths catches new child TextMeshes; the translator's
-            // drift-tracked refresh re-pins meshes whose transforms the game rewrites
-            // every frame. Both lists are deliberately tiny.
-            ScanRebuildingPaths();
+            // Periodic work for content the game rebuilds in place.
+            // GetComponentsInChildren allocates and walks a subtree, so keep it off
+            // the per-frame path. Drift refresh stays per-frame because it only touches
+            // meshes already opted into the tiny drift-tracked set.
+            rebuildingScanTimer += deltaTime;
+            if (rebuildingScanTimer >= LocalizationConstants.REBUILDING_SCAN_INTERVAL)
+            {
+                ScanRebuildingPaths();
+                rebuildingScanTimer = 0f;
+            }
             translator.RefreshDriftTrackedAdjustments();
 
             // Always update EveryFrame
@@ -512,6 +518,7 @@ namespace MWC_Localization_Core
             fastPollingTimer = 0f;
             slowPollingTimer = 0f;
             visibilityPollingTimer = 0f;
+            rebuildingScanTimer = LocalizationConstants.REBUILDING_SCAN_INTERVAL;
             InitializeDefaultPathRules();
         }
     }


### PR DESCRIPTION
- Throttle rebuilt TextMesh parent scans so the magazine product monitor no longer walks its subtree every frame.
- Reduce expensive inactive PlayMaker FSM index rebuilds by preferring cached hits and only refreshing on stale cache misses.
- Add maintenance backoff for the FSM text hook and only report changes when translations actually mutate runtime data.

I noticed a runtime performance degradation in the plugin, and this patch aims to mitigate it by reducing unnecessary per-frame work and expensive cache rebuild operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved translation update efficiency with adaptive polling delays when no changes occur
  * Reduced per-frame overhead by throttling UI rebuild scans
  * Enhanced FSM lookup performance with improved caching mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->