### PR TITLE
Translate TV schedule text line by line

### DIFF
--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -90,7 +90,6 @@ namespace MWC_Localization_Core
             }
         }
 
-        private static readonly string[] PosUseStateNames = new string[] { "State 1", "State 3", "State 4", "State 5" };
         private static readonly string[] PosTyperCommandStateNames = new string[] { "Player input", "Player input 2", "Type", "Type 2", "Drive mem", "Disk mem", "Change baud" };
 
         private static readonly FsmStrategyTarget[] GamePosTargets = new FsmStrategyTarget[]
@@ -355,8 +354,7 @@ namespace MWC_Localization_Core
         private bool TryApplyGamePosFsmTranslations()
         {
             bool anyChanged = false;
-            bool hasAnyTarget = false;
-            ApplyStrategyTargets(GamePosTargets, ref anyChanged, ref hasAnyTarget);
+            ApplyStrategyTargets(GamePosTargets, ref anyChanged);
 
             if (anyChanged)
             {
@@ -369,8 +367,7 @@ namespace MWC_Localization_Core
         private bool TryApplyGameTeletextBottomlineFsmTranslations()
         {
             bool anyChanged = false;
-            bool hasAnyTarget = false;
-            ApplyStrategyTargets(GameTeletextTargets, ref anyChanged, ref hasAnyTarget);
+            ApplyStrategyTargets(GameTeletextTargets, ref anyChanged);
 
             if (anyChanged)
             {
@@ -383,9 +380,8 @@ namespace MWC_Localization_Core
         private bool TryApplyGameTeletextWeatherUpdaterFsmTranslations()
         {
             bool anyChanged = false;
-            bool hasAnyTarget = false;
 
-            ApplyStrategyTargets(GameTeletextWeatherTargets, ref anyChanged, ref hasAnyTarget);
+            ApplyStrategyTargets(GameTeletextWeatherTargets, ref anyChanged);
 
             List<PlayMakerFSM> ennusteDataFsms = GetEnnusteDataFsms();
             for (int i = 0; i < ennusteDataFsms.Count; i++)
@@ -395,7 +391,7 @@ namespace MWC_Localization_Core
                     continue;
 
                 LogReadyOnce("TTX_WX_READY", "[FsmTextHook] Teletext weather updater FSM targets are ready.");
-                ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
+                ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged);
             }
 
             if (anyChanged)
@@ -409,9 +405,8 @@ namespace MWC_Localization_Core
         private bool TryApplyGameUnemployPaperFsmTranslations()
         {
             bool anyChanged = false;
-            bool hasAnyTarget = false;
 
-            ApplyStrategyTargets(GameUnemployPaperTargets, ref anyChanged, ref hasAnyTarget);
+            ApplyStrategyTargets(GameUnemployPaperTargets, ref anyChanged);
 
             if (anyChanged)
             {
@@ -424,9 +419,8 @@ namespace MWC_Localization_Core
         private bool TryApplyGameConlineChatFsmTranslations()
         {
             bool anyChanged = false;
-            bool hasAnyTarget = false;
 
-            ApplyStrategyTargets(GameConlineTargets, ref anyChanged, ref hasAnyTarget);
+            ApplyStrategyTargets(GameConlineTargets, ref anyChanged);
 
             if (anyChanged)
             {
@@ -436,7 +430,7 @@ namespace MWC_Localization_Core
             return anyChanged;
         }
 
-        private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged, ref bool hasAnyTarget)
+        private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged)
         {
             if (targets == null || targets.Length == 0)
                 return;
@@ -453,11 +447,11 @@ namespace MWC_Localization_Core
 
                 LogReadyOnce(target.ReadyLogKey, target.ReadyLogMessage);
 
-                ApplyStrategyForTarget(target, fsm, ref anyChanged, ref hasAnyTarget);
+                ApplyStrategyForTarget(target, fsm, ref anyChanged);
             }
         }
 
-        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
+        private void ApplyStrategyForTarget(FsmStrategyTarget target, PlayMakerFSM fsm, ref bool anyChanged)
         {
             if (target == null || fsm == null)
                 return;
@@ -470,7 +464,6 @@ namespace MWC_Localization_Core
                     anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, "State 4", 0, false);
                     anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, "State 5", 0, false);
                     anyChanged |= ApplyAllStateSetStringValueTranslation(fsm);
-                    hasAnyTarget |= HasAnyState(fsm, PosUseStateNames);
                     break;
 
                 case FsmStrategyType.PosTyper:
@@ -486,33 +479,28 @@ namespace MWC_Localization_Core
                     // Do not translate setter actions in states that can carry live command text.
                     anyChanged |= ApplyAllStateSetStringValueTranslation(fsm, PosTyperCommandStateNames);
                     anyChanged |= ApplyAllStateSetFsmStringTranslation(fsm, PosTyperCommandStateNames);
-                    hasAnyTarget |= HasAnyState(fsm, PosTyperCommandStateNames);
                     break;
 
                 case FsmStrategyType.TeletextBuildStringPattern:
                     anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, target.StateName, target.ActionIndex, true);
-                    hasAnyTarget |= HasState(fsm, target.StateName);
                     break;
 
                 case FsmStrategyType.TeletextBuildStringSimple:
                     // Translate only part[0] (e.g. "KLO " -> localized prefix) and leave the
                     // dynamic time/date parts 1 and 2 untouched.
                     anyChanged |= ApplyBuildStringActionStringPartsTranslation(fsm, target.StateName, target.ActionIndex, false, 1, 2);
-                    hasAnyTarget |= HasState(fsm, target.StateName);
                     break;
 
                 case FsmStrategyType.TeletextWeatherUpdaterTokens:
-                    ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged, ref hasAnyTarget);
+                    ApplyWeatherUpdaterTokenTranslations(fsm, ref anyChanged);
                     break;
 
                 case FsmStrategyType.UnemployPaperButtonVariables:
                     anyChanged |= ApplyUnemployPaperButtonVariableTranslations(fsm);
-                    hasAnyTarget = true;
                     break;
 
                 case FsmStrategyType.ConlineChatStatus:
                     anyChanged |= ApplyConlineChatStatusTranslations(fsm);
-                    hasAnyTarget = true;
                     break;
             }
 
@@ -539,15 +527,13 @@ namespace MWC_Localization_Core
             return fsm != null && fsm.Fsm != null && fsm.Fsm.Initialized && fsm.FsmStates != null;
         }
 
-        private void ApplyWeatherUpdaterTokenTranslations(PlayMakerFSM fsm, ref bool anyChanged, ref bool hasAnyTarget)
+        private void ApplyWeatherUpdaterTokenTranslations(PlayMakerFSM fsm, ref bool anyChanged)
         {
             if (fsm == null)
                 return;
 
             anyChanged |= ApplyStateSetStringValueActionIndexesTranslation(fsm, "State 4", 0, 1);
             anyChanged |= ApplyStateSetStringValueActionIndexesTranslation(fsm, "State 6", 0, 1);
-
-            hasAnyTarget |= HasState(fsm, "State 4") || HasState(fsm, "State 6");
         }
 
         private bool ApplyUnemployPaperButtonVariableTranslations(PlayMakerFSM fsm)
@@ -658,34 +644,6 @@ namespace MWC_Localization_Core
                 cachedEnnusteDataFsms);
 
             return cachedEnnusteDataFsms;
-        }
-
-        private bool HasState(PlayMakerFSM fsm, string stateName)
-        {
-            if (fsm == null || fsm.FsmStates == null)
-                return false;
-
-            for (int i = 0; i < fsm.FsmStates.Length; i++)
-            {
-                if (fsm.FsmStates[i] != null && fsm.FsmStates[i].Name == stateName)
-                    return true;
-            }
-
-            return false;
-        }
-
-        private bool HasAnyState(PlayMakerFSM fsm, string[] stateNames)
-        {
-            if (fsm == null || stateNames == null || stateNames.Length == 0)
-                return false;
-
-            for (int i = 0; i < stateNames.Length; i++)
-            {
-                if (HasState(fsm, stateNames[i]))
-                    return true;
-            }
-
-            return false;
         }
 
         private PlayMakerFSM FindFsmWithState(GameObject obj, string stateName)
@@ -825,8 +783,9 @@ namespace MWC_Localization_Core
             bool patternResolved = false;
             if (allowPatternSplit && isBuildStringFast)
             {
-                patternResolved = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts);
-                changed = patternResolved;
+                bool patternWrote;
+                patternResolved = ApplyBuildStringFastPatternTranslation(fsm, stateName, actionIndex, parts, out patternWrote);
+                changed |= patternWrote;
             }
 
             // If the pattern path rewrote parts[0]/parts[2] around parts[1], DON'T then
@@ -847,8 +806,10 @@ namespace MWC_Localization_Core
             return changed;
         }
 
-        private bool ApplyBuildStringFastPatternTranslation(PlayMakerFSM fsm, string stateName, int actionIndex, HutongGames.PlayMaker.FsmString[] parts)
+        private bool ApplyBuildStringFastPatternTranslation(PlayMakerFSM fsm, string stateName, int actionIndex, HutongGames.PlayMaker.FsmString[] parts, out bool wrote)
         {
+            wrote = false;
+
             if (patternMatcher == null || fsm == null || parts == null || parts.Length < 3)
                 return false;
 
@@ -882,27 +843,25 @@ namespace MWC_Localization_Core
             // If parts[0]/parts[2] already match the translated prefix/suffix, the pattern
             // has already been applied on a previous tick. Return true so the caller still
             // treats this as "pattern-resolved" (skipping per-part translation) without
-            // needlessly writing back identical values.
+            // reporting a write that would reset maintenance backoff.
             string currentPart0 = part0.Value ?? string.Empty;
             string currentPart2 = part2.Value ?? string.Empty;
             if (currentPart0 == newPrefix && currentPart2 == newSuffix)
                 return true;
 
-            bool changed = false;
-
             if (part0.Value != newPrefix)
             {
                 part0.Value = newPrefix;
-                changed = true;
+                wrote = true;
             }
 
             if (part2.Value != newSuffix)
             {
                 part2.Value = newSuffix;
-                changed = true;
+                wrote = true;
             }
 
-            return changed;
+            return true;
         }
 
         private bool ApplyStringAddNewLineActionStringPartTranslation(PlayMakerFSM fsm, string stateName, int actionIndex, int stringPartIndex)

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -20,10 +20,13 @@ namespace MWC_Localization_Core
         private HashSet<string> loggedReadyTargets = new HashSet<string>();
         private List<PlayMakerFSM> cachedEnnusteDataFsms = new List<PlayMakerFSM>();
         private float lastEnnusteDataFsmScanTime = -10f;
+        private int unchangedMaintenanceTicks = 0;
 
         private static readonly WaitForSeconds BootstrapPollDelay = new WaitForSeconds(0.5f);
         private static readonly WaitForSeconds MaintenancePollDelay = new WaitForSeconds(1.0f);
+        private static readonly WaitForSeconds SettledMaintenancePollDelay = new WaitForSeconds(3.0f);
         private const float EnnusteDataRescanInterval = 2f;
+        private const int SettledMaintenanceThreshold = 3;
 
         // Reflection cache: (Type, fieldName) -> FieldInfo to avoid repeated GetField calls
         private static readonly Dictionary<System.Type, Dictionary<string, FieldInfo>> reflectionCache
@@ -275,8 +278,19 @@ namespace MWC_Localization_Core
 
                 if (currentScene == "GAME")
                 {
-                    TryApplyGameTranslations();
-                    yield return MaintenancePollDelay;
+                    bool changed = TryApplyGameTranslations();
+                    if (changed)
+                    {
+                        unchangedMaintenanceTicks = 0;
+                    }
+                    else
+                    {
+                        unchangedMaintenanceTicks++;
+                    }
+
+                    yield return unchangedMaintenanceTicks >= SettledMaintenanceThreshold
+                        ? SettledMaintenancePollDelay
+                        : MaintenancePollDelay;
                     continue;
                 }
 
@@ -284,10 +298,10 @@ namespace MWC_Localization_Core
             }
         }
 
-        private void TryApplyGameTranslations()
+        private bool TryApplyGameTranslations()
         {
             if (translations == null)
-                return;
+                return false;
 
             bool anyChanged = false;
             anyChanged |= TryApplyGamePosFsmTranslations();
@@ -301,6 +315,8 @@ namespace MWC_Localization_Core
                 string targetLabel = string.IsNullOrEmpty(appliedTarget) ? "GAME" : appliedTarget;
                 CoreConsole.Print("[FsmTextHook] FSM text translations applied (" + targetLabel + ")");
             }
+
+            return anyChanged;
         }
 
         private bool TryApplyMainMenuTranslations()
@@ -347,7 +363,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME POS";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameTeletextBottomlineFsmTranslations()
@@ -361,7 +377,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Teletext Bottomline";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameTeletextWeatherUpdaterFsmTranslations()
@@ -387,7 +403,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Teletext Weather";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameUnemployPaperFsmTranslations()
@@ -402,7 +418,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME UnemployPaper";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private bool TryApplyGameConlineChatFsmTranslations()
@@ -417,7 +433,7 @@ namespace MWC_Localization_Core
                 appliedTarget = "GAME Conline Chat";
             }
 
-            return anyChanged || hasAnyTarget;
+            return anyChanged;
         }
 
         private void ApplyStrategyTargets(FsmStrategyTarget[] targets, ref bool anyChanged, ref bool hasAnyTarget)

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -238,7 +238,7 @@ namespace MWC_Localization_Core
 
         /// <summary>
         /// Re-pin drift-tracked TextMeshes whose transform was rewritten by the game
-        /// since the last frame. Called every LateUpdate by the monitor.
+        /// since the last frame. Invoked each frame from UnifiedTextMeshMonitor.Update().
         /// </summary>
         public void RefreshDriftTrackedAdjustments()
         {

--- a/LocalizationConstants.cs
+++ b/LocalizationConstants.cs
@@ -10,6 +10,7 @@ namespace MWC_Localization_Core
         public const float FAST_POLLING_INTERVAL = 0.15f;           // ~6.6 times per second
         public const float SLOW_POLLING_INTERVAL = 1.0f;            // Once per second
         public const float VISIBILITY_POLLING_INTERVAL = 0.35f;     // ~3 times per second
+        public const float REBUILDING_SCAN_INTERVAL = 0.25f;        // Dynamic rebuilt UI scan cadence
         public const float ARRAY_MONITOR_INTERVAL = 2.0f;           // Check arrays every 2 seconds
     }
 }

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -163,7 +163,7 @@ namespace MWC_Localization_Core
             EnsureFsmIndexBuilt();
             AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);
 
-            if (results.Count == 0 && IsFsmIndexStale())
+            if (IsFsmIndexStale())
             {
                 RebuildFsmIndex(Time.realtimeSinceStartup);
                 AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);

--- a/MLCUtils.cs
+++ b/MLCUtils.cs
@@ -112,17 +112,39 @@ namespace MWC_Localization_Core
 
             string cacheKey = objectPath + "|" + fsmName;
 
-            EnsureFsmIndexFresh();
-
             PlayMakerFSM cachedFsm;
-            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm)
-                && cachedFsm != null
-                && cachedFsm.gameObject != null)
+            if (TryGetCachedFsm(cacheKey, out cachedFsm))
             {
                 return cachedFsm;
             }
 
+            // Full inactive FSM scans are expensive. Build the index once, then only
+            // refresh on cache misses after a cooldown so optional/missing targets do
+            // not create a steady frametime spike.
+            if (!fsmIndexBuilt || IsFsmIndexStale())
+            {
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+                if (TryGetCachedFsm(cacheKey, out cachedFsm))
+                {
+                    return cachedFsm;
+                }
+            }
+
             return null;
+        }
+
+        private static bool TryGetCachedFsm(string cacheKey, out PlayMakerFSM cachedFsm)
+        {
+            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm))
+            {
+                if (cachedFsm != null && cachedFsm.gameObject != null)
+                    return true;
+
+                inactiveFsmPathNameCache.Remove(cacheKey);
+            }
+
+            cachedFsm = null;
+            return false;
         }
 
         /// <summary>
@@ -138,8 +160,29 @@ namespace MWC_Localization_Core
             if (string.IsNullOrEmpty(pathPrefix) || string.IsNullOrEmpty(fsmName))
                 return;
 
-            EnsureFsmIndexFresh();
+            EnsureFsmIndexBuilt();
+            AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);
 
+            if (results.Count == 0 && IsFsmIndexStale())
+            {
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+                AddMatchingFsmsByPrefix(pathPrefix, fsmName, results);
+            }
+        }
+
+        private static bool IsFsmIndexStale()
+        {
+            return Time.realtimeSinceStartup - lastFsmIndexBuildTime >= FSM_INDEX_REFRESH_INTERVAL;
+        }
+
+        private static void EnsureFsmIndexBuilt()
+        {
+            if (!fsmIndexBuilt)
+                RebuildFsmIndex(Time.realtimeSinceStartup);
+        }
+
+        private static void AddMatchingFsmsByPrefix(string pathPrefix, string fsmName, List<PlayMakerFSM> results)
+        {
             foreach (PlayMakerFSM fsm in inactiveFsmPathNameCache.Values)
             {
                 if (fsm == null || fsm.gameObject == null)
@@ -154,15 +197,6 @@ namespace MWC_Localization_Core
                     results.Add(fsm);
                 }
             }
-        }
-
-        private static void EnsureFsmIndexFresh()
-        {
-            float now = Time.realtimeSinceStartup;
-            if (fsmIndexBuilt && now - lastFsmIndexBuildTime < FSM_INDEX_REFRESH_INTERVAL)
-                return;
-
-            RebuildFsmIndex(now);
         }
 
         private static void RebuildFsmIndex(float timestamp)

--- a/MonitoringStrategy.cs
+++ b/MonitoringStrategy.cs
@@ -25,11 +25,12 @@ namespace MWC_Localization_Core
 
         /// <summary>
         /// Like Persistent, but the parent itself rebuilds child GameObjects while the
-        /// screen is open (e.g. magazine sheets). The parent's subtree is re-scanned 
-        /// every LateUpdate so new child TextMeshes are translated and adjusted 
-        /// on the same frame they appear. Pair with TextAdjustment.DriftTrackedPathPatterns
-        /// when the rebuilt transforms also need their position offset re-pinned.
-        /// Every entry pays a per-frame GetComponentsInChildren walk - use sparingly.
+        /// screen is open (e.g. magazine sheets). UnifiedTextMeshMonitor.Update()
+        /// invokes ScanRebuildingPaths() for these parents so new child TextMeshes
+        /// are translated and adjusted after they appear. Pair with
+        /// TextAdjustment.DriftTrackedPathPatterns when the rebuilt transforms also
+        /// need their position offset re-pinned.
+        /// Each scan pays a GetComponentsInChildren walk - use sparingly.
         /// </summary>
         PersistentRebuilding,
 

--- a/TextAdjustment.cs
+++ b/TextAdjustment.cs
@@ -30,8 +30,9 @@ namespace MWC_Localization_Core
     {
         // Paths whose transforms the game rewrites repeatedly (e.g. magazine sheets that
         // get rebuilt while open). TextMeshes whose path matches any entry get drift-
-        // tracked and re-pinned every LateUpdate. Keep this list small - every entry
-        // pays a per-frame cost proportional to the number of TextMeshes it has touched.
+        // tracked and re-pinned from UnifiedTextMeshMonitor.Update(). Keep this list
+        // small - every entry pays a per-frame cost proportional to the number of
+        // TextMeshes it has touched.
         private static readonly string[] DriftTrackedPathPatterns =
         {
             "Sheets/Magazine/Products",
@@ -138,7 +139,8 @@ namespace MWC_Localization_Core
 
         /// <summary>
         /// Re-pin drift-tracked TextMeshes whose local position the game has rewritten
-        /// since the last frame. Caller invokes every LateUpdate. No-op when nothing is tracked.
+        /// since the last frame. Called from UnifiedTextMeshMonitor.Update().
+        /// No-op when nothing is tracked.
         /// </summary>
         public void Refresh()
         {

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -188,7 +188,20 @@ namespace MWC_Localization_Core
 
             // Check if translation exists
             if (!translations.TryGetValue(normalizedKey, out string translation))
+            {
+                if (currentText.IndexOf('\n') >= 0)
+                {
+                    string lineTranslation = TranslateTextByLines(currentText);
+                    if (lineTranslation != currentText)
+                    {
+                        ApplyCustomFont(textMesh, path);
+                        textMesh.text = lineTranslation;
+                        return true;
+                    }
+                }
+
                 return false;
+            }
 
             // Already-localized text still needs its font + adjustments applied so
             // one-shot monitors can stop cleanly and so drift-tracked meshes get
@@ -205,6 +218,60 @@ namespace MWC_Localization_Core
             textMesh.text = translation;
 
             return true;
+        }
+
+        private string TranslateTextByLines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            string[] lines = text.Split('\n');
+            bool changed = false;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string translatedLine = TranslateLinePreservingPrefix(lines[i]);
+                if (translatedLine != lines[i])
+                {
+                    lines[i] = translatedLine;
+                    changed = true;
+                }
+            }
+
+            if (!changed)
+                return text;
+
+            return string.Join("\n", lines);
+        }
+
+        private string TranslateLinePreservingPrefix(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+                return line;
+
+            string lineNoCr = line.Replace("\r", string.Empty);
+            string translated;
+            if (translations.TryGetValue(MLCUtils.FormatUpperKey(lineNoCr), out translated))
+                return translated;
+
+            int textStart = FindTextStartAfterNumericPrefix(lineNoCr);
+            if (textStart <= 0 || textStart >= lineNoCr.Length)
+                return line;
+
+            string suffix = lineNoCr.Substring(textStart);
+            if (!translations.TryGetValue(MLCUtils.FormatUpperKey(suffix), out translated))
+                return line;
+
+            return lineNoCr.Substring(0, textStart) + translated;
+        }
+
+        private int FindTextStartAfterNumericPrefix(string line)
+        {
+            int i = 0;
+            while (i < line.Length && (char.IsDigit(line[i]) || line[i] == '.' || line[i] == ':' || line[i] == ',' || char.IsWhiteSpace(line[i])))
+                i++;
+
+            return i;
         }
 
         /// <summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -239,7 +239,7 @@ namespace MWC_Localization_Core
         
         /// <summary>
         /// Re-pin drift-tracked TextMeshes (e.g. magazine sheets the game rebuilds).
-        /// Called every LateUpdate by the monitor.
+        /// Invoked each frame from UnifiedTextMeshMonitor.Update().
         /// </summary>
         public void RefreshDriftTrackedAdjustments()
         {

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -131,6 +131,9 @@ namespace MWC_Localization_Core
             AddPathRule("GUI/HUD/Jailtime/HUDValue", MonitoringStrategy.FastPolling);
             AddPathRule("Systems/TV/TVGraphics/CHAT/Day", MonitoringStrategy.FastPolling);
             AddPathRule("Systems/TV/TVGraphics/CHAT/Moderator", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanSat1/Text", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanSun1/Text", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanWeek/Text", MonitoringStrategy.FastPolling);
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/HEADER/Texts/Status", MonitoringStrategy.FastPolling);
 
             // Teletext/FSM displays are primarily translated at array/FSM source level.

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -68,6 +68,7 @@ namespace MWC_Localization_Core
         private float fastPollingTimer;
         private float slowPollingTimer;
         private float visibilityPollingTimer;
+        private float rebuildingScanTimer = LocalizationConstants.REBUILDING_SCAN_INTERVAL;
 
         // Path-based monitoring rules (pattern -> strategy mapping)
         private Dictionary<string, MonitoringStrategy> pathRules;
@@ -341,10 +342,10 @@ namespace MWC_Localization_Core
 
         /// <summary>
         /// Re-run Register() for PersistentRebuilding parents so newly-spawned child
-        /// TextMeshes are picked up the same frame they appear. Register() already
+        /// TextMeshes are picked up shortly after they appear. Register() already
         /// deduplicates by instanceID; the dominant cost is one
-        /// GetComponentsInChildren&lt;TextMesh&gt;(true) per parent, so rebuildingPaths
-        /// must stay tiny.
+        /// GetComponentsInChildren&lt;TextMesh&gt;(true) per parent, so this scan is
+        /// throttled instead of running every frame.
         /// </summary>
         private void ScanRebuildingPaths()
         {
@@ -359,11 +360,16 @@ namespace MWC_Localization_Core
         /// </summary>
         public void Update(float deltaTime)
         {
-            // Per-frame work for content the game rebuilds in place.
-            // ScanRebuildingPaths catches new child TextMeshes; the translator's
-            // drift-tracked refresh re-pins meshes whose transforms the game rewrites
-            // every frame. Both lists are deliberately tiny.
-            ScanRebuildingPaths();
+            // Periodic work for content the game rebuilds in place.
+            // GetComponentsInChildren allocates and walks a subtree, so keep it off
+            // the per-frame path. Drift refresh stays per-frame because it only touches
+            // meshes already opted into the tiny drift-tracked set.
+            rebuildingScanTimer += deltaTime;
+            if (rebuildingScanTimer >= LocalizationConstants.REBUILDING_SCAN_INTERVAL)
+            {
+                ScanRebuildingPaths();
+                rebuildingScanTimer = 0f;
+            }
             translator.RefreshDriftTrackedAdjustments();
 
             // Always update EveryFrame
@@ -512,6 +518,7 @@ namespace MWC_Localization_Core
             fastPollingTimer = 0f;
             slowPollingTimer = 0f;
             visibilityPollingTimer = 0f;
+            rebuildingScanTimer = LocalizationConstants.REBUILDING_SCAN_INTERVAL;
             InitializeDefaultPathRules();
         }
     }


### PR DESCRIPTION
- Monitor the real TV schedule graphics paths and add a line-based fallback that preserves numeric time prefixes while translating each schedule entry.

Translation lines:
GSM K-18 CHAT = CHAT GSM K-18
TÄNÄÄN = HOJE
RALLISPRINT SM = RALLYSPRINT SM
VIITTÄ VAILLE FILMI = FILME QUASE ÀS CINCO
TULEVAA OHJELMISTOA = PRÓXIMAS ATRAÇÕES
MUSAMAKASIINI = ARQUIVO MUSICAL
UUTISET JA SÄÄ = NOTÍCIAS DO TEMPO
USKO USKOMATONTA = ACREDITE SE QUISER
HERÄÄ SUOMI = ACORDA, FINLÂNDIA
KULUTUSKANAVA = CANAL DE CONSUMO

ohjelmat sunnuntai = programação de domingo
ohjelmat maanantai = programação de segunda
ohjelmat tiistai = programação de terça
ohjelmat keskiviikko = programação de quarta
ohjelmat torstai = programação de quinta
ohjelmat perjantai = programação de sexta
ohjelmat lauantai = programação de sábado

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-line translation support for text containing line breaks.
  * Extended localization coverage to additional TV graphics UI elements.

* **Improvements**
  * Improved translation application efficiency through adaptive settling behavior.
  * Optimized internal FSM cache management for faster lookups.
  * Enhanced monitoring performance through periodic scan throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->