### PR TITLE
Handle TV schedule line translations

### DIFF
--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -188,7 +188,20 @@ namespace MWC_Localization_Core
 
             // Check if translation exists
             if (!translations.TryGetValue(normalizedKey, out string translation))
+            {
+                if (currentText.IndexOf('\n') >= 0)
+                {
+                    string lineTranslation = TranslateTextByLines(currentText);
+                    if (lineTranslation != currentText)
+                    {
+                        ApplyCustomFont(textMesh, path);
+                        textMesh.text = lineTranslation;
+                        return true;
+                    }
+                }
+
                 return false;
+            }
 
             // Already-localized text still needs its font + adjustments applied so
             // one-shot monitors can stop cleanly and so drift-tracked meshes get
@@ -205,6 +218,60 @@ namespace MWC_Localization_Core
             textMesh.text = translation;
 
             return true;
+        }
+
+        private string TranslateTextByLines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            string[] lines = text.Split('\n');
+            bool changed = false;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string translatedLine = TranslateLinePreservingPrefix(lines[i]);
+                if (translatedLine != lines[i])
+                {
+                    lines[i] = translatedLine;
+                    changed = true;
+                }
+            }
+
+            if (!changed)
+                return text;
+
+            return string.Join("\n", lines);
+        }
+
+        private string TranslateLinePreservingPrefix(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+                return line;
+
+            string lineNoCr = line.Replace("\r", string.Empty);
+            string translated;
+            if (translations.TryGetValue(MLCUtils.FormatUpperKey(lineNoCr), out translated))
+                return translated;
+
+            int textStart = FindTextStartAfterNumericPrefix(lineNoCr);
+            if (textStart <= 0 || textStart >= lineNoCr.Length)
+                return line;
+
+            string suffix = lineNoCr.Substring(textStart);
+            if (!translations.TryGetValue(MLCUtils.FormatUpperKey(suffix), out translated))
+                return line;
+
+            return lineNoCr.Substring(0, textStart) + translated;
+        }
+
+        private int FindTextStartAfterNumericPrefix(string line)
+        {
+            int i = 0;
+            while (i < line.Length && (char.IsDigit(line[i]) || line[i] == '.' || line[i] == ':' || line[i] == ',' || char.IsWhiteSpace(line[i])))
+                i++;
+
+            return i;
         }
 
         /// <summary>
@@ -239,7 +306,7 @@ namespace MWC_Localization_Core
         
         /// <summary>
         /// Re-pin drift-tracked TextMeshes (e.g. magazine sheets the game rebuilds).
-        /// Called every LateUpdate by the monitor.
+        /// Invoked each frame from UnifiedTextMeshMonitor.Update().
         /// </summary>
         public void RefreshDriftTrackedAdjustments()
         {

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -256,11 +256,11 @@ namespace MWC_Localization_Core
 
             int textStart = FindTextStartAfterNumericPrefix(lineNoCr);
             if (textStart <= 0 || textStart >= lineNoCr.Length)
-                return line;
+                return lineNoCr;
 
             string suffix = lineNoCr.Substring(textStart);
             if (!translations.TryGetValue(MLCUtils.FormatUpperKey(suffix), out translated))
-                return line;
+                return lineNoCr;
 
             return lineNoCr.Substring(0, textStart) + translated;
         }

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -256,13 +256,13 @@ namespace MWC_Localization_Core
 
             int textStart = FindTextStartAfterNumericPrefix(lineNoCr);
             if (textStart <= 0 || textStart >= lineNoCr.Length)
-                return lineNoCr;
+                return line;
 
             string suffix = lineNoCr.Substring(textStart);
             if (!translations.TryGetValue(MLCUtils.FormatUpperKey(suffix), out translated))
-                return lineNoCr;
+                return line;
 
-            return lineNoCr.Substring(0, textStart) + translated;
+            return line.Substring(0, textStart) + translated;
         }
 
         private int FindTextStartAfterNumericPrefix(string line)

--- a/UnifiedTextMeshMonitor.cs
+++ b/UnifiedTextMeshMonitor.cs
@@ -131,6 +131,9 @@ namespace MWC_Localization_Core
             AddPathRule("Systems/TV/TVGraphics/CHAT/Day", MonitoringStrategy.FastPolling);
             AddPathRule("Systems/TV/TVGraphics/CHAT/Moderator", MonitoringStrategy.FastPolling);
             AddPathRule("Systems/TV/Teletext/VKTekstiTV/HEADER/Texts/Status", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanSat1/Text", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanSun1/Text", MonitoringStrategy.FastPolling);
+            AddPathRule("Systems/TV/TVGraphics/GFXTanaanWeek/Text", MonitoringStrategy.FastPolling);
 
             // Teletext/FSM displays are primarily translated at array/FSM source level.
             // Use one-shot late registration to avoid rescanning large TV trees continuously.


### PR DESCRIPTION
- Add monitoring for the real TV schedule graphics paths and translate multiline schedule text line by line while preserving time prefixes.

Translation lines:
GSM K-18 CHAT = CHAT GSM K-18
TÄNÄÄN = HOJE
RALLISPRINT SM = RALLYSPRINT SM
VIITTÄ VAILLE FILMI = FILME QUASE ÀS CINCO
TULEVAA OHJELMISTOA = PRÓXIMAS ATRAÇÕES
MUSAMAKASIINI = ARQUIVO MUSICAL
UUTISET JA SÄÄ = NOTÍCIAS DO TEMPO
USKO USKOMATONTA = ACREDITE SE QUISER
HERÄÄ SUOMI = ACORDA, FINLÂNDIA
KULUTUSKANAVA = CANAL DE CONSUMO

ohjelmat sunnuntai = programação de domingo
ohjelmat maanantai = programação de segunda
ohjelmat tiistai = programação de terça
ohjelmat keskiviikko = programação de quarta
ohjelmat torstai = programação de quinta
ohjelmat perjantai = programação de sexta
ohjelmat lauantai = programação de sábado

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-line text is now supported in the translation system.
  * Added enhanced monitoring for TV graphics text display elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->