### PR TITLE
Reduce Runtime Polling and Retire Completed Monitors

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -11,6 +11,12 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "ArrayListProxyHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Slow; } }
+        public bool IsComplete { get { return IsArrayMonitoringComplete && IsFontMonitoringComplete; } }
+        public bool IsArrayMonitoringComplete { get { return translatedArrays.Count >= arrayPaths.Count; } }
+        public bool IsFontMonitoringComplete
+        {
+            get { return parentSearchPaths != null && completedParentPaths.Count >= parentSearchPaths.Count; }
+        }
 
         // Reference to main translation dictionary (from Plugin)
         private TranslationDictionary mainTranslations;

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -14,6 +14,7 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "FsmTextHook"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Fast; } }
+        public bool IsComplete { get { return false; } }
 
         public int InitialPass()
         {

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -50,7 +50,6 @@ namespace MWC_Localization_Core
         private readonly HashSet<string> warnedTargets = new HashSet<string>();
         private readonly HashSet<int> initializedFsmIds = new HashSet<int>();
 
-        private float lastSourcePollTime = -10f;
         private int pendingTargetIndex;
         private FsmTarget servicePaymentLineTarget;
         private FsmTarget atmTransactionDescriptionTarget;
@@ -100,7 +99,6 @@ namespace MWC_Localization_Core
 
         public void ResetRuntimeState()
         {
-            lastSourcePollTime = -10f;
             pendingTargetIndex = 0;
             ClearRuntimeCaches();
         }
@@ -120,23 +118,17 @@ namespace MWC_Localization_Core
             if (!isMainMenu && !isGame)
                 return false;
 
-            // Match the ExtraTranslateSource129 execution model: FSM sources are patched
-            // during explicit scene/reload passes. Runtime calls only touch small dynamic
-            // sources that the game rebuilds after opening a screen.
+            // Runtime polling only handles sources that are known to be rebuilt while
+            // their sheets are open. Other FSM sources are patched by scene/reload passes.
+            // Scheduler (LateUpdateHandler) already paces this surface at FSM_SOURCE_POLL_INTERVAL.
             if (!force)
             {
                 if (!isGame)
                     return false;
 
-                bool immediateChanged = TryApplyRallyClassSources();
-                if (!ShouldPoll(ref lastSourcePollTime, LocalizationConstants.FSM_SOURCE_POLL_INTERVAL))
-                    return immediateChanged;
-
-                bool runtimeChanged = immediateChanged;
+                bool runtimeChanged = false;
                 runtimeChanged |= TryApplyFleetariServicePaymentBreakdownSource();
                 runtimeChanged |= TryApplyAtmTransactionDescriptionSource();
-                runtimeChanged |= TryApplyTvChatDaySource();
-                runtimeChanged |= TryApplyGameTeletextWeatherUpdaterDirectTranslations();
 
                 return runtimeChanged;
             }
@@ -1749,15 +1741,6 @@ namespace MWC_Localization_Core
         private static bool IsTranslatableDirectStringField(string fieldName)
         {
             return fieldName == "stringValue" || fieldName == "text" || fieldName == "m_stringGenerated";
-        }
-
-        private static bool ShouldPoll(ref float lastPollTime, float interval)
-        {
-            if (Time.realtimeSinceStartup - lastPollTime < interval)
-                return false;
-
-            lastPollTime = Time.realtimeSinceStartup;
-            return true;
         }
 
         private void ClearRuntimeCaches()

--- a/GuiTextMonitor.cs
+++ b/GuiTextMonitor.cs
@@ -11,6 +11,7 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "GuiTextMonitor"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.PerFrame; } }
+        public bool IsComplete { get { return false; } }
 
         private class GuiTextEntry
         {

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -13,6 +13,8 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "HashTableProxyHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Slow; } }
+        public bool IsComplete { get { return IsMonitoringComplete; } }
+        public bool IsMonitoringComplete { get { return translatedPaths.Count >= targetPaths.Count; } }
 
         private MagazineTextHandler magazineHandler;
         private readonly HashSet<string> targetPaths = new HashSet<string>();

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -78,6 +78,16 @@ namespace MWC_Localization_Core
                         }
                         break;
 
+                    case SurfaceCadence.Medium:
+                        if (now >= nextTickTimes[i])
+                        {
+                            int translated = s.MonitorTick(dt);
+                            if (translated > 0)
+                                CoreConsole.Print($"[LateUpdateHandler] {s.Name}: translated {translated} item(s)");
+                            nextTickTimes[i] = now + LocalizationConstants.CHAT_MONITOR_INTERVAL;
+                        }
+                        break;
+
                     case SurfaceCadence.Slow:
                         if (now >= nextTickTimes[i])
                         {

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -12,6 +12,8 @@ namespace MWC_Localization_Core
     {
         private List<ITranslationSurface> surfaces;
         private float[] nextTickTimes;
+        private bool[] loggedRetired;
+        private bool loggedAllRetired;
         private LocalizationConfig config;
         private Func<bool> isGameSceneReady;
         private bool isInitialized;
@@ -25,6 +27,8 @@ namespace MWC_Localization_Core
             this.config = config;
             this.isGameSceneReady = isGameSceneReady;
             nextTickTimes = surfaces != null ? new float[surfaces.Count] : new float[0];
+            loggedRetired = surfaces != null ? new bool[surfaces.Count] : new bool[0];
+            loggedAllRetired = false;
 
             // Stagger Slow surfaces so they don't all fire on the same frame.
             // Each Slow surface fires every ARRAY_MONITOR_INTERVAL, but consecutive
@@ -61,9 +65,26 @@ namespace MWC_Localization_Core
 
             float now = Time.time;
             float dt = Time.deltaTime;
+            bool allSlowRetired = !loggedAllRetired;
             for (int i = 0; i < surfaces.Count; i++)
             {
                 ITranslationSurface s = surfaces[i];
+
+                if (s.IsComplete)
+                {
+                    if (!loggedRetired[i])
+                    {
+                        CoreConsole.Print($"[LateUpdateHandler] {s.Name} complete; retiring");
+                        loggedRetired[i] = true;
+                    }
+                    continue;
+                }
+
+                // Track whether every Slow surface (array/proxy monitors) has retired.
+                // Surfaces that monitor live data (HUD/Fast/Medium) are intentionally ignored.
+                if (s.Cadence == SurfaceCadence.Slow)
+                    allSlowRetired = false;
+
                 switch (s.Cadence)
                 {
                     case SurfaceCadence.PerFrame:
@@ -102,6 +123,12 @@ namespace MWC_Localization_Core
                         // No tick.
                         break;
                 }
+            }
+
+            if (allSlowRetired && !loggedAllRetired)
+            {
+                CoreConsole.Print("[LateUpdateHandler] All Slow-cadence surfaces complete; scheduler retired for this scene");
+                loggedAllRetired = true;
             }
         }
 

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -16,7 +16,6 @@ namespace MWC_Localization_Core
         public const float ARRAY_MONITOR_STEP_INTERVAL = ARRAY_MONITOR_INTERVAL / 4f;      // Four staggered passes share one full array/proxy monitoring cycle.
         public const float FSM_SOURCE_POLL_INTERVAL = 0.2f;                                // Check dynamic FSM sources 5 times per second
         public const float GUI_MONITOR_RETRY_INTERVAL = 1.0f;                              // Retry missing GUI TextMesh references once per second
-        public const float FSM_INDEX_REFRESH_INTERVAL = 1.0f;                              // Refresh inactive FSM lookup index every 1s
     }
 
     /// <summary>

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -12,9 +12,10 @@ namespace MWC_Localization_Core
     /// </summary>
     public static class LocalizationConstants
     {
-        public const float ARRAY_MONITOR_INTERVAL = 2.0f;                                  // Check arrays every 2 seconds
+        public const float ARRAY_MONITOR_INTERVAL = 4.0f;                                  // Check arrays every 4 seconds
         public const float ARRAY_MONITOR_STEP_INTERVAL = ARRAY_MONITOR_INTERVAL / 4f;      // Four staggered passes share one full array/proxy monitoring cycle.
-        public const float FSM_SOURCE_POLL_INTERVAL = 0.2f;                                // Check dynamic FSM sources 5 times per second
+        public const float CHAT_MONITOR_INTERVAL = 1.0f;                                   // Check dynamic TV chat messages once per second
+        public const float FSM_SOURCE_POLL_INTERVAL = 5.0f;                                // Check Fleetari/ATM FSM dynamic sources once every 5 seconds
         public const float GUI_MONITOR_RETRY_INTERVAL = 1.0f;                              // Retry missing GUI TextMesh references once per second
     }
 

--- a/LocalizationUtils.cs
+++ b/LocalizationUtils.cs
@@ -6,8 +6,7 @@ using System.Text;
 namespace MWC_Localization_Core
 {
     /// <summary>
-    /// String normalization, GameObject path/find caching, and inactive-FSM lookup helpers
-    /// used throughout the localization pipeline.
+    /// String normalization and GameObject path/find caching used throughout the localization pipeline.
     /// </summary>
     public static class LocalizationUtils
     {
@@ -40,10 +39,6 @@ namespace MWC_Localization_Core
         private static Dictionary<GameObject, string> pathCache = new Dictionary<GameObject, string>();
         // Cache for expensive GameObject.Find(path) lookups
         private static Dictionary<string, GameObject> gameObjectFindCache = new Dictionary<string, GameObject>();
-        // Scene-local FSM index for inactive lookup helpers (resolved via Resources.FindObjectsOfTypeAll)
-        private static Dictionary<string, PlayMakerFSM> inactiveFsmPathNameCache = new Dictionary<string, PlayMakerFSM>();
-        private static bool fsmIndexBuilt = false;
-        private static float lastFsmIndexBuildTime = -1000f;
 
         // Reusable scratch buffers for path construction. Unity is single-threaded so no locking needed.
         private static Transform[] pathChain = new Transform[32];
@@ -121,95 +116,6 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Find PlayMakerFSM by object path + FSM name, including inactive objects.
-        /// Uses a cache and falls back to Resources.FindObjectsOfTypeAll when needed.
-        /// </summary>
-        public static PlayMakerFSM FindFsmIncludingInactiveByPathAndName(string objectPath, string fsmName)
-        {
-            if (string.IsNullOrEmpty(objectPath) || string.IsNullOrEmpty(fsmName))
-                return null;
-
-            string cacheKey = objectPath + "|" + fsmName;
-
-            EnsureFsmIndexFresh();
-
-            PlayMakerFSM cachedFsm;
-            if (inactiveFsmPathNameCache.TryGetValue(cacheKey, out cachedFsm)
-                && cachedFsm != null
-                && cachedFsm.gameObject != null)
-            {
-                return cachedFsm;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Find PlayMakerFSMs by path prefix + FSM name, including inactive objects.
-        /// Results are written into the provided list to avoid per-call allocations.
-        /// </summary>
-        public static void FindFsmsIncludingInactiveByPathPrefixAndName(string pathPrefix, string fsmName, List<PlayMakerFSM> results)
-        {
-            if (results == null)
-                return;
-
-            results.Clear();
-            if (string.IsNullOrEmpty(pathPrefix) || string.IsNullOrEmpty(fsmName))
-                return;
-
-            EnsureFsmIndexFresh();
-
-            foreach (PlayMakerFSM fsm in inactiveFsmPathNameCache.Values)
-            {
-                if (fsm == null || fsm.gameObject == null)
-                    continue;
-
-                if (fsm.FsmName != fsmName)
-                    continue;
-
-                string path = GetGameObjectPath(fsm.gameObject);
-                if (path.StartsWith(pathPrefix))
-                {
-                    results.Add(fsm);
-                }
-            }
-        }
-
-        private static void EnsureFsmIndexFresh()
-        {
-            float now = Time.realtimeSinceStartup;
-            if (fsmIndexBuilt && now - lastFsmIndexBuildTime < LocalizationConstants.FSM_INDEX_REFRESH_INTERVAL)
-                return;
-
-            RebuildFsmIndex(now);
-        }
-
-        private static void RebuildFsmIndex(float timestamp)
-        {
-            inactiveFsmPathNameCache.Clear();
-            lastFsmIndexBuildTime = timestamp;
-            fsmIndexBuilt = true;
-
-            PlayMakerFSM[] allFsms = Resources.FindObjectsOfTypeAll<PlayMakerFSM>();
-            if (allFsms == null)
-                return;
-
-            for (int i = 0; i < allFsms.Length; i++)
-            {
-                PlayMakerFSM fsm = allFsms[i];
-                if (fsm == null || fsm.gameObject == null || string.IsNullOrEmpty(fsm.FsmName))
-                    continue;
-
-                string path = GetGameObjectPath(fsm.gameObject);
-                string key = path + "|" + fsm.FsmName;
-                if (!inactiveFsmPathNameCache.ContainsKey(key))
-                {
-                    inactiveFsmPathNameCache[key] = fsm;
-                }
-            }
-        }
-
-        /// <summary>
         /// Shared accessor for all TextMeshes including inactive ones.
         /// </summary>
         public static TextMesh[] GetAllTextMeshesIncludingInactive()
@@ -225,13 +131,10 @@ namespace MWC_Localization_Core
         {
             pathCache.Clear();
             gameObjectFindCache.Clear();
-            inactiveFsmPathNameCache.Clear();
-            fsmIndexBuilt = false;
-            lastFsmIndexBuildTime = -1000f;
         }
 
         /// <summary>
-        /// Drop only entries that reference destroyed Unity objects, and reset the scene-scoped FSM index.
+        /// Drop only entries that reference destroyed Unity objects.
         /// Lets stable paths (HUD, indicators) survive a MainMenu->GAME transition cold-start free.
         /// </summary>
         public static void PruneCaches()
@@ -267,11 +170,6 @@ namespace MWC_Localization_Core
                 for (int i = 0; i < staleFindKeys.Count; i++)
                     gameObjectFindCache.Remove(staleFindKeys[i]);
             }
-
-            // FSM index is scene-scoped; force a rebuild on next access.
-            inactiveFsmPathNameCache.Clear();
-            fsmIndexBuilt = false;
-            lastFsmIndexBuildTime = -1000f;
         }
     }
 

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -99,11 +99,15 @@ namespace MWC_Localization_Core
 
             // MagazineTextHandler is both a service (used by other surfaces via ctx.Magazine)
             // and itself a surface, so the same instance appears in both places.
+            // TeletextChatHandler reads chat translation data from TeletextHandler, so it
+            // takes a reference to the shared instance.
+            var teletext = new TeletextHandler();
             surfaces = new List<ITranslationSurface>
             {
                 new GuiTextMonitor(),
                 magazineHandler,
-                new TeletextHandler(),
+                teletext,
+                new TeletextChatHandler(teletext),
                 new ArrayListProxyHandler(),
                 new HashTableProxyHandler(),
                 new FsmTextHook(),

--- a/MWC_Localization_Core.csproj
+++ b/MWC_Localization_Core.csproj
@@ -79,6 +79,7 @@
     <Compile Include="TextAdjustment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TeletextHandler.cs" />
+    <Compile Include="TeletextChatHandler.cs" />
     <Compile Include="TextMeshTranslator.cs" />
     <Compile Include="TranslationDictionary.cs" />
     <Compile Include="TranslationFileParser.cs" />

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -15,6 +15,7 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "MagazineTextHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Slow; } }
+        public bool IsComplete { get { return yellowPagesSourcesResolved; } }
 
         private Dictionary<string, string> magazineTranslations = new Dictionary<string, string>();
         private bool yellowPagesSourcesResolved;

--- a/TeletextChatHandler.cs
+++ b/TeletextChatHandler.cs
@@ -16,6 +16,7 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "TeletextChatHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Medium; } }
+        public bool IsComplete { get { return false; } }
 
         private readonly TeletextHandler teletext;
 

--- a/TeletextChatHandler.cs
+++ b/TeletextChatHandler.cs
@@ -1,0 +1,190 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MWC_Localization_Core
+{
+    /// <summary>
+    /// Dynamic TV-chat monitor. Runs at Medium cadence (CHAT_MONITOR_INTERVAL) so chat messages
+    /// stay responsive while the slower static-teletext loop in TeletextHandler can retire once done.
+    /// Per-slot value cache skips slots that haven't changed since the previous tick.
+    ///
+    /// Translation data is owned by TeletextHandler (loaded from translate_teletext.txt) and read
+    /// through TeletextHandler.TryGetChatTranslations.
+    /// </summary>
+    public class TeletextChatHandler : ITranslationSurface
+    {
+        public string Name { get { return "TeletextChatHandler"; } }
+        public SurfaceCadence Cadence { get { return SurfaceCadence.Medium; } }
+
+        private readonly TeletextHandler teletext;
+
+        private PlayMakerArrayListProxy[] chatProxies;
+        private bool chatProxiesResolved;
+
+        // Last processed value per chat slot, keyed by proxy instance id.
+        private readonly Dictionary<int, List<string>> chatLastValuesByProxy = new Dictionary<int, List<string>>();
+
+        public TeletextChatHandler(TeletextHandler teletext)
+        {
+            this.teletext = teletext;
+        }
+
+        public void Initialize(TranslationContext ctx)
+        {
+            // Translation data lives on TeletextHandler; nothing to wire up here.
+        }
+
+        public int InitialPass()
+        {
+            return MonitorAndTranslateChatMessages();
+        }
+
+        public int MonitorTick(float deltaTime)
+        {
+            return MonitorAndTranslateChatMessages();
+        }
+
+        public void Reset()
+        {
+            chatProxies = null;
+            chatProxiesResolved = false;
+            chatLastValuesByProxy.Clear();
+        }
+
+        public void ClearTranslations()
+        {
+            // Translation data is owned by TeletextHandler; runtime caches reset via Reset().
+        }
+
+        private int MonitorAndTranslateChatMessages()
+        {
+            try
+            {
+                if (!chatProxiesResolved)
+                {
+                    GameObject dataObject = LocalizationUtils.FindGameObjectCached(TeletextHandler.ChatMessagesPath);
+                    if (dataObject == null)
+                        return 0;
+
+                    chatProxies = dataObject.GetComponents<PlayMakerArrayListProxy>();
+                    chatProxiesResolved = true;
+                }
+
+                if (chatProxies == null || chatProxies.Length == 0)
+                    return 0;
+
+                Dictionary<string, string> exact;
+                List<string> indexed;
+                if (!teletext.TryGetChatTranslations(out exact, out indexed))
+                    return 0;
+
+                int totalTranslated = 0;
+                for (int i = 0; i < chatProxies.Length; i++)
+                {
+                    PlayMakerArrayListProxy proxy = chatProxies[i];
+                    if (proxy == null || !string.Equals(proxy.referenceName, "Messages", System.StringComparison.Ordinal))
+                        continue;
+
+                    int translated = TranslateChangedChatMessagesProxy(proxy, exact, indexed);
+                    if (translated > 0)
+                    {
+                        CoreConsole.Print($"[TeletextChatHandler] Translated '{TeletextHandler.ChatMessagesCategoryName}' with {translated} items");
+                        totalTranslated += translated;
+                    }
+                }
+
+                return totalTranslated;
+            }
+            catch (System.Exception ex)
+            {
+                CoreConsole.Error($"[TeletextChatHandler] Error monitoring TV chat messages: {ex.Message}");
+                return 0;
+            }
+        }
+
+        private int TranslateChangedChatMessagesProxy(
+            PlayMakerArrayListProxy proxy,
+            Dictionary<string, string> translations,
+            List<string> indexedFallback)
+        {
+            if (proxy == null || proxy._arrayList == null)
+                return 0;
+
+            ArrayList arrayList = proxy._arrayList;
+            int instanceId = proxy.GetInstanceID();
+            List<string> lastValues;
+            if (!chatLastValuesByProxy.TryGetValue(instanceId, out lastValues))
+            {
+                lastValues = new List<string>(arrayList.Count);
+                chatLastValuesByProxy[instanceId] = lastValues;
+            }
+
+            while (lastValues.Count < arrayList.Count)
+                lastValues.Add(null);
+            while (lastValues.Count > arrayList.Count)
+                lastValues.RemoveAt(lastValues.Count - 1);
+
+            bool hasIndexFallback = indexedFallback != null && indexedFallback.Count > 0;
+
+            int translatedCount = 0;
+            int fallbackCount = 0;
+            int nonEmptySourceIndex = -1;
+
+            for (int i = 0; i < arrayList.Count; i++)
+            {
+                if (arrayList[i] == null)
+                {
+                    lastValues[i] = null;
+                    continue;
+                }
+
+                string original = arrayList[i].ToString();
+                string normalizedOriginal = original.Trim();
+                if (string.IsNullOrEmpty(normalizedOriginal))
+                {
+                    lastValues[i] = original;
+                    continue;
+                }
+
+                nonEmptySourceIndex++;
+                if (lastValues[i] == original)
+                    continue;
+
+                string translationKey = TranslationFileParser.UnescapeString(normalizedOriginal);
+                string finalValue = original;
+
+                string translation;
+                if (translations.TryGetValue(translationKey, out translation))
+                {
+                    if (original != translation)
+                    {
+                        finalValue = translation;
+                        arrayList[i] = translation;
+                        translatedCount++;
+                    }
+                }
+                else if (hasIndexFallback && nonEmptySourceIndex < indexedFallback.Count)
+                {
+                    string indexTranslation = indexedFallback[nonEmptySourceIndex];
+                    if (!string.IsNullOrEmpty(indexTranslation) && original != indexTranslation)
+                    {
+                        finalValue = indexTranslation;
+                        arrayList[i] = indexTranslation;
+                        translatedCount++;
+                        fallbackCount++;
+                    }
+                }
+
+                lastValues[i] = finalValue;
+            }
+
+            if (fallbackCount > 0)
+            {
+                CoreConsole.Print($"[TeletextChatHandler] '{TeletextHandler.ChatMessagesCategoryName}': Used index fallback for {fallbackCount} changed items");
+            }
+
+            return translatedCount;
+        }
+    }
+}

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -22,6 +22,8 @@ namespace MWC_Localization_Core
     {
         public string Name { get { return "TeletextHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Slow; } }
+        public bool IsComplete { get { return IsStaticArrayMonitoringComplete; } }
+        public bool IsStaticArrayMonitoringComplete { get; private set; }
 
         // Dynamic TV chat is split into TeletextChatHandler (Medium cadence). This handler
         // owns the loaded translation data; the chat handler reads it via TryGetChatTranslations.
@@ -148,9 +150,13 @@ namespace MWC_Localization_Core
         /// </summary>
         public int MonitorAndTranslateArrays()
         {
+            if (IsStaticArrayMonitoringComplete)
+                return 0;
+
             try
             {
                 int totalTranslated = 0;
+                bool allStaticArraysComplete = true;
 
                 foreach (var pathPrefix in pathPrefixes.Keys)
                 {
@@ -163,7 +169,11 @@ namespace MWC_Localization_Core
                     {
                         // First time accessing this path - cache proxies
                         GameObject dataObject = LocalizationUtils.FindGameObjectCached(pathPrefix);
-                        if (dataObject == null) continue;
+                        if (dataObject == null)
+                        {
+                            allStaticArraysComplete = false;
+                            continue;
+                        }
 
                         proxies = dataObject.GetComponents<PlayMakerArrayListProxy>();
                         proxyCache[pathPrefix] = proxies;
@@ -207,8 +217,14 @@ namespace MWC_Localization_Core
                                 translatedArrays.Add(arrayKey);
                             }
                         }
+
+                        if (!translatedArrays.Contains(arrayKey))
+                            allStaticArraysComplete = false;
                     }
                 }
+
+                if (allStaticArraysComplete)
+                    IsStaticArrayMonitoringComplete = true;
 
                 return totalTranslated;
             }
@@ -307,6 +323,7 @@ namespace MWC_Localization_Core
         {
             translatedArrays.Clear();
             proxyCache.Clear();
+            IsStaticArrayMonitoringComplete = false;
         }
     }
 }

--- a/TeletextHandler.cs
+++ b/TeletextHandler.cs
@@ -23,6 +23,11 @@ namespace MWC_Localization_Core
         public string Name { get { return "TeletextHandler"; } }
         public SurfaceCadence Cadence { get { return SurfaceCadence.Slow; } }
 
+        // Dynamic TV chat is split into TeletextChatHandler (Medium cadence). This handler
+        // owns the loaded translation data; the chat handler reads it via TryGetChatTranslations.
+        public const string ChatMessagesPath = "Systems/TV/ChatMessages";
+        public const string ChatMessagesCategoryName = "ChatMessages.Messages";
+
         private TranslationDictionary sharedTranslations;
         private string teletextFilePath;
 
@@ -40,11 +45,13 @@ namespace MWC_Localization_Core
         // Total translations loaded on the most recent LoadTeletextTranslations call.
         private int lastLoadedTranslationCount = 0;
         
-        // GameObject path to category mapping
+        // GameObject path to category mapping.
+        // ChatMessagesPath is registered so the alias setup still applies, but
+        // MonitorAndTranslateArrays skips it — TeletextChatHandler owns the chat tick.
         private Dictionary<string, string> pathPrefixes = new Dictionary<string, string>
         {
             { "Systems/TV/Teletext/VKTekstiTV/Database", "" },  // Use referenceName directly
-            { "Systems/TV/ChatMessages", "ChatMessages" },      // Prefix with "ChatMessages."
+            { ChatMessagesPath, "ChatMessages" },               // Prefix with "ChatMessages."
         };
         
         // Path Prefix Proxy cache
@@ -125,6 +132,17 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Exposes the loaded chat-messages translation tables for TeletextChatHandler.
+        /// Returns false if no chat data was loaded from translate_teletext.txt.
+        /// </summary>
+        public bool TryGetChatTranslations(out Dictionary<string, string> exact, out List<string> indexed)
+        {
+            categoryTranslations.TryGetValue(ChatMessagesCategoryName, out exact);
+            indexBasedTranslations.TryGetValue(ChatMessagesCategoryName, out indexed);
+            return exact != null && exact.Count > 0;
+        }
+
+        /// <summary>
         /// Monitor and translate teletext arrays
         /// Returns number of new items translated
         /// </summary>
@@ -136,6 +154,10 @@ namespace MWC_Localization_Core
 
                 foreach (var pathPrefix in pathPrefixes.Keys)
                 {
+                    // Dynamic TV chat is handled by TeletextChatHandler at Medium cadence.
+                    if (pathPrefix == ChatMessagesPath)
+                        continue;
+
                     PlayMakerArrayListProxy[] proxies;
                     if (!proxyCache.ContainsKey(pathPrefix))
                     {
@@ -163,17 +185,15 @@ namespace MWC_Localization_Core
                         // Create unique key for this array
                         string arrayKey = $"{pathPrefix}[{i}]:{refName}";
 
-                        // Try translating only if not already done
+                        // Try translating only if not already done. Chat is excluded above,
+                        // so everything reaching here is static and can be marked done.
                         if (!translatedArrays.Contains(arrayKey))
                         {
                             int translated = TranslateArrayListProxy(proxies[i], categoryName);
 
-                            // Mark as processed
-                            // ... if it doesn't require constant monitoring...
-                            bool isDynamic = categoryName == "ChatMessages.Messages";
-                            // ... or if the array is already populated ...
+                            // Mark as processed if it's already populated, or there are no translations
+                            // available (to avoid repeated checks).
                             bool isPopulated = proxies[i] != null && proxies[i]._arrayList != null && proxies[i]._arrayList.Count > 0;
-                            // ... or if there are no translations available (to avoid repeated checks)
                             bool isTranslationAvailable = categoryTranslations.ContainsKey(categoryName) &&
                                                           categoryTranslations[categoryName].Count > 0;
 
@@ -184,7 +204,7 @@ namespace MWC_Localization_Core
                                     CoreConsole.Print($"[TeletextHandler] Translated '{categoryName}' with {translated} items");
                                     totalTranslated += translated;
                                 }
-                                if (!isDynamic) translatedArrays.Add(arrayKey); // Mark as translated
+                                translatedArrays.Add(arrayKey);
                             }
                         }
                     }

--- a/TranslationSurface.cs
+++ b/TranslationSurface.cs
@@ -13,9 +13,11 @@ namespace MWC_Localization_Core
         OncePerScene,
         /// <summary>Every LateUpdate frame. For HUD-style monitors that mirror text per frame.</summary>
         PerFrame,
-        /// <summary>~5 ticks/sec. For small dynamic FSM sources that the game rebuilds per screen open.</summary>
+        /// <summary>FSM_SOURCE_POLL_INTERVAL. For small dynamic FSM sources that the game rebuilds per screen open.</summary>
         Fast,
-        /// <summary>~2 ticks/sec, staggered across surfaces. For ArrayList/HashTable proxies that lazy-load.</summary>
+        /// <summary>CHAT_MONITOR_INTERVAL (~1s). For dynamic-but-cheap monitors like TV chat with per-slot caching.</summary>
+        Medium,
+        /// <summary>ARRAY_MONITOR_INTERVAL, staggered across surfaces. For ArrayList/HashTable proxies that lazy-load.</summary>
         Slow,
     }
 

--- a/TranslationSurface.cs
+++ b/TranslationSurface.cs
@@ -65,6 +65,10 @@ namespace MWC_Localization_Core
         /// <summary>How often MonitorTick should fire after InitialPass.</summary>
         SurfaceCadence Cadence { get; }
 
+        /// <summary>True once the surface has nothing more to do; scheduler stops ticking it.
+        /// Surfaces that monitor inherently-live data (HUD, dynamic FSM sources, chat) return false.</summary>
+        bool IsComplete { get; }
+
         /// <summary>Wire up dependencies. Called once after construction and again on F8 reload.</summary>
         void Initialize(TranslationContext ctx);
 


### PR DESCRIPTION
## Summary

This PR reduces unnecessary runtime polling and background monitor work after the game scene has stabilized.

## Changes

- Reduced FSM source polling to run once every 5 seconds.
- Limited runtime FSM polling to only the dynamic sources that still need periodic updates.
- Removed unused inactive FSM lookup/index code from `MLCUtils`.
- Removed the unused `FSM_INDEX_REFRESH_INTERVAL` constant.

- Split dynamic TV chat monitoring into its own dedicated path.
- TV chat messages now run on a separate monitor instead of depending on the slower general teletext array cycle.
- Added per-slot chat caching so unchanged chat messages are skipped between checks.

- Added completion flags for:
  - static teletext arrays
  - PlayMaker array sources
  - PlayMaker hash table sources
  - array TextMesh font passes

- Updated `LateUpdateHandler` so completed monitor steps are retired instead of continuing to wake up on the staggered scheduler.
- Added debug logs when each monitor step is completed and retired.

## Why This Is Better

The previous runtime loop kept checking some systems even after their work was already complete. This was not causing major frametime spikes anymore, but it still added unnecessary background work.

With this change, static/lazy-loaded sources are monitored only until they are resolved. Once complete, their scheduler steps are retired. Dynamic systems that still need updates, such as TV chat and Fleetari/ATM sources, keep their own smaller polling paths.

This keeps translations responsive while reducing ongoing LateUpdate work after the scene has settled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic translation support for teletext chat messages with real-time updates.

* **Improvements**
  * Optimized array monitoring and FSM polling intervals for better performance and responsiveness.
  * Enhanced translation surface monitoring with completion detection to prevent unnecessary background processing.

* **Refactor**
  * Streamlined translation utilities by removing unused lookup methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potatosalad775/MWC_Localization_Core/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->