### PR TITLE
Fix late rally and magazine text translations

### DIFF
--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -140,7 +140,6 @@ namespace MWC_Localization_Core
                 changed |= TryApplyFleetariServicePaymentBreakdownSource();
                 changed |= TryApplyAtmTransactionDescriptionSource();
                 changed |= TryApplyTvChatDaySource();
-                changed |= TryApplyRallyClassSources();
                 changed |= TryApplyGameTeletextWeatherUpdaterDirectTranslations();
             }
 
@@ -735,6 +734,14 @@ namespace MWC_Localization_Core
             changed |= TryApplyRallyClassSource(rallyPlayerResultsTarget, "State 1", 5);
             changed |= TryApplyRallyClassSource(rallyRegistrationClassTarget, "State 1", 3);
             return changed;
+        }
+
+        internal bool ApplyRallyClassSourcesForCurrentScene()
+        {
+            if (Application.loadedLevelName != "GAME")
+                return false;
+
+            return TryApplyRallyClassSources();
         }
 
         private bool TryApplyRallyClassSource(FsmTarget target, string stateName, int actionIndex)
@@ -1755,6 +1762,47 @@ namespace MWC_Localization_Core
             resolvedTargets.Clear();
             warnedTargets.Clear();
             initializedFsmIds.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Targeted per-frame repair for rally class labels. This keeps the broad FSM
+    /// hook on its normal cadence while catching the exact frame where the sheet
+    /// rebuilds the visible rally class text.
+    /// </summary>
+    public class RallyClassTextHook : ITranslationSurface
+    {
+        public string Name { get { return "RallyClassTextHook"; } }
+        public SurfaceCadence Cadence { get { return SurfaceCadence.PerFrame; } }
+        public bool IsComplete { get { return false; } }
+
+        private readonly FsmTextHook fsmTextHook;
+
+        public RallyClassTextHook(FsmTextHook fsmTextHook)
+        {
+            this.fsmTextHook = fsmTextHook;
+        }
+
+        public void Initialize(TranslationContext ctx)
+        {
+        }
+
+        public int InitialPass()
+        {
+            return MonitorTick(0f);
+        }
+
+        public int MonitorTick(float deltaTime)
+        {
+            return fsmTextHook != null && fsmTextHook.ApplyRallyClassSourcesForCurrentScene() ? 1 : 0;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void ClearTranslations()
+        {
         }
     }
 }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -102,15 +102,18 @@ namespace MWC_Localization_Core
             // TeletextChatHandler reads chat translation data from TeletextHandler, so it
             // takes a reference to the shared instance.
             var teletext = new TeletextHandler();
+            var fsmTextHook = new FsmTextHook();
             surfaces = new List<ITranslationSurface>
             {
                 new GuiTextMonitor(),
                 magazineHandler,
+                new MagazineYellowLineHook(magazineHandler),
                 teletext,
                 new TeletextChatHandler(teletext),
                 new ArrayListProxyHandler(),
                 new HashTableProxyHandler(),
-                new FsmTextHook(),
+                fsmTextHook,
+                new RallyClassTextHook(fsmTextHook),
             };
 
             for (int i = 0; i < surfaces.Count; i++)

--- a/MagazineTextHandler.cs
+++ b/MagazineTextHandler.cs
@@ -19,6 +19,7 @@ namespace MWC_Localization_Core
 
         private Dictionary<string, string> magazineTranslations = new Dictionary<string, string>();
         private bool yellowPagesSourcesResolved;
+        private readonly List<PlayMakerFSM> yellowLineFsmCache = new List<PlayMakerFSM>();
         private string assetsFolder;
 
         public void Initialize(TranslationContext ctx)
@@ -107,6 +108,7 @@ namespace MWC_Localization_Core
         public void ResetRuntimeState()
         {
             yellowPagesSourcesResolved = false;
+            yellowLineFsmCache.Clear();
         }
 
         public int TranslateAllSources()
@@ -192,6 +194,80 @@ namespace MWC_Localization_Core
 
             translated += SyncMagazineYellowLineDisplay(fsm);
             return translated;
+        }
+
+        internal int SyncYellowLineDisplaysForCurrentScene(out bool foundDisplayLine)
+        {
+            foundDisplayLine = false;
+            if (Application.loadedLevelName != "GAME")
+                return 0;
+
+            List<PlayMakerFSM> fsms = GetYellowLineFsms();
+            int changed = 0;
+            for (int i = 0; i < fsms.Count; i++)
+            {
+                if (HasYellowLineDisplayValue(fsms[i]))
+                    foundDisplayLine = true;
+
+                changed += SyncMagazineYellowLineDisplay(fsms[i]);
+            }
+
+            return changed;
+        }
+
+        private List<PlayMakerFSM> GetYellowLineFsms()
+        {
+            if (AreYellowLineFsmsValid())
+                return yellowLineFsmCache;
+
+            yellowLineFsmCache.Clear();
+
+            GameObject root = LocalizationUtils.FindGameObjectCached("Sheets/YellowPagesMagazine");
+            if (root == null)
+                return yellowLineFsmCache;
+
+            PlayMakerFSM[] fsms = root.GetComponentsInChildren<PlayMakerFSM>(true);
+            if (fsms == null || fsms.Length == 0)
+                return yellowLineFsmCache;
+
+            for (int i = 0; i < fsms.Length; i++)
+            {
+                PlayMakerFSM fsm = fsms[i];
+                if (fsm == null || fsm.gameObject == null || FsmUtils.GetFsmName(fsm) != "Generate")
+                    continue;
+
+                string path = LocalizationUtils.GetGameObjectPath(fsm.gameObject);
+                if (string.IsNullOrEmpty(path) || path.IndexOf("/Lines/YellowLine", System.StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                yellowLineFsmCache.Add(fsm);
+            }
+
+            return yellowLineFsmCache;
+        }
+
+        private bool AreYellowLineFsmsValid()
+        {
+            if (yellowLineFsmCache.Count == 0)
+                return false;
+
+            for (int i = 0; i < yellowLineFsmCache.Count; i++)
+            {
+                PlayMakerFSM fsm = yellowLineFsmCache[i];
+                if (fsm == null || fsm.gameObject == null)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool HasYellowLineDisplayValue(PlayMakerFSM fsm)
+        {
+            if (fsm == null || fsm.gameObject == null || fsm.FsmVariables == null)
+                return false;
+
+            HutongGames.PlayMaker.FsmString line = fsm.FsmVariables.GetFsmString("Line");
+            return line != null && !string.IsNullOrEmpty(line.Value);
         }
 
         private int SyncMagazineYellowLineDisplay(PlayMakerFSM fsm)
@@ -349,6 +425,77 @@ namespace MWC_Localization_Core
             }
 
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Per-frame repair pass for Yellow Pages display lines that are rebuilt while the magazine is open.
+    /// Keeps the broader magazine source scan on its normal slow cadence.
+    /// </summary>
+    public class MagazineYellowLineHook : ITranslationSurface
+    {
+        public string Name { get { return "MagazineYellowLineHook"; } }
+        public SurfaceCadence Cadence { get { return SurfaceCadence.PerFrame; } }
+        public bool IsComplete { get { return isComplete; } }
+
+        private readonly MagazineTextHandler magazineHandler;
+        private bool isComplete;
+        private bool hasFoundDisplayLine;
+        private float settleTimer;
+        private const float SettleSeconds = 5.0f;
+
+        public MagazineYellowLineHook(MagazineTextHandler magazineHandler)
+        {
+            this.magazineHandler = magazineHandler;
+        }
+
+        public void Initialize(TranslationContext ctx)
+        {
+        }
+
+        public int InitialPass()
+        {
+            return MonitorTick(0f);
+        }
+
+        public int MonitorTick(float deltaTime)
+        {
+            if (isComplete || magazineHandler == null)
+                return 0;
+
+            bool foundDisplayLine;
+            int changed = magazineHandler.SyncYellowLineDisplaysForCurrentScene(out foundDisplayLine);
+            if (foundDisplayLine)
+                hasFoundDisplayLine = true;
+
+            if (!hasFoundDisplayLine)
+                return changed;
+
+            if (changed > 0)
+            {
+                settleTimer = 0f;
+                return changed;
+            }
+
+            settleTimer += deltaTime > 0f ? deltaTime : 0.02f;
+            if (settleTimer >= SettleSeconds)
+                isComplete = true;
+
+            return changed;
+        }
+
+        public void Reset()
+        {
+            isComplete = false;
+            hasFoundDisplayLine = false;
+            settleTimer = 0f;
+        }
+
+        public void ClearTranslations()
+        {
+            isComplete = false;
+            hasFoundDisplayLine = false;
+            settleTimer = 0f;
         }
     }
 }


### PR DESCRIPTION
## Summary

This commit fixes late translation updates for Rally class labels and Yellow Pages magazine display lines that are rebuilt after the initial scene translation pass.

### Changes

- Added a targeted `RallyClassTextHook` translation surface.
- Rally class labels now run through a narrow per-frame repair hook instead of being handled inside the broader `FsmTextHook` polling flow.
- Added `ApplyRallyClassSourcesForCurrentScene()` to expose Rally class source repair only when the current scene is `GAME`.
- Removed `TryApplyRallyClassSources()` from the normal forced `FsmTextHook` update path, keeping the broad FSM hook on its regular cadence.
- Registered a shared `FsmTextHook` instance so both the normal FSM surface and the new Rally repair hook use the same hook state.
- Added a targeted `MagazineYellowLineHook` translation surface.
- Added cached Yellow Pages `YellowLine` FSM discovery through `yellowLineFsmCache`.
- Added `SyncYellowLineDisplaysForCurrentScene()` to repair Yellow Pages display lines only in the `GAME` scene.
- Added validation for cached YellowLine FSMs to avoid repeated unnecessary lookups.
- Added detection for active YellowLine display values before starting the settle timer.
- The Yellow Pages display-line hook runs while the magazine is opening and stops after the translated lines settle.
- Added reset/clear handling for the new YellowLine FSM cache and hook state.

### Why This Is Better

Some Rally and Yellow Pages text is rebuilt after the initial scene pass, so the translation can appear late or briefly return to the original value.

The previous approach kept more of this work inside broader polling/update paths. That worked, but it made the normal FSM and magazine handlers responsible for catching very specific late rebuild cases.

This commit makes those cases explicit and targeted:

- Rally class labels get a narrow per-frame repair surface.
- Yellow Pages display lines get a temporary per-frame repair surface while the magazine is opening.
- The broader FSM hook and magazine source scan can keep their normal cadence.
- The Yellow Pages hook stops after the lines settle, avoiding a permanent per-frame magazine scan.

### Result

Late Rally class text and Yellow Pages display lines are repaired more reliably without increasing the cost of the broader runtime polling systems.

The fix is more focused, easier to reason about, and avoids using a continuous generic scan for a problem that only happens during specific rebuild windows.

### Status

This commit is ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rally class translation handling in game scenes
  * Enhanced magazine display text synchronization for translated content

* **Performance**
  * Optimized translation processing with improved caching mechanisms
  * Refined per-frame translation surface updates for better efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potatosalad775/MWC_Localization_Core/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->