### PR TITLE
Add GameObject adjustment and remove obsolete drift-tracking logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,6 @@ When adding new state to a surface, ensure both `Reset()` (runtime caches) and `
 - If you add a new long-lived cache, wire it into the corresponding surface's `Reset()` or, for global utilities, into `ClearCaches`/`PruneCaches` in `LocalizationUtils`.
 - Exception: `fontBundle` is intentionally `static` because MSCLoader can reconstruct the `Mod` instance during a session — reloading the AssetBundle leaks Unity assets.
 
-### Drift-tracked paths
-
-The game rewrites the transform of some sheets after we adjust them (e.g. `Sheets/Magazine/Products`). `TextAdjustment.DriftTrackedPathPatterns` is a small **code-side** whitelist of substring matches; meshes whose path matches get re-pinned in `LateUpdate` via `LocalizationConfig.RefreshDriftTrackedAdjustments`. Adding a path is a code change, not a config change.
-
 ### Forced-font path prefixes
 
 `LocalizationConfig.ForcedFontPathPrefixes` lists path roots that get the custom font applied even when the text isn't in the translation dictionary (teletext display, computer POS, unemployment letter, rally/service sheets, TV graphics). Check via `LocalizationConfig.IsForcedFontPath(path)`. New "show foreign font correctly even when text stays original" cases go here.

--- a/LateUpdateHandler.cs
+++ b/LateUpdateHandler.cs
@@ -14,17 +14,14 @@ namespace MWC_Localization_Core
         private float[] nextTickTimes;
         private bool[] loggedRetired;
         private bool loggedAllRetired;
-        private LocalizationConfig config;
         private Func<bool> isGameSceneReady;
         private bool isInitialized;
 
         public void Initialize(
             List<ITranslationSurface> surfaces,
-            LocalizationConfig config,
             Func<bool> isGameSceneReady)
         {
             this.surfaces = surfaces;
-            this.config = config;
             this.isGameSceneReady = isGameSceneReady;
             nextTickTimes = surfaces != null ? new float[surfaces.Count] : new float[0];
             loggedRetired = surfaces != null ? new bool[surfaces.Count] : new bool[0];
@@ -59,9 +56,6 @@ namespace MWC_Localization_Core
                 return;
             if (isGameSceneReady == null || !isGameSceneReady())
                 return;
-
-            if (config != null)
-                config.RefreshDriftTrackedAdjustments();
 
             float now = Time.time;
             float dt = Time.deltaTime;

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -62,7 +62,9 @@ namespace MWC_Localization_Core
         public string LanguageCode { get; private set; } = "en-US";
         public Dictionary<string, string> FontMappings { get; private set; } = new Dictionary<string, string>();
         public List<TextAdjustment> TextAdjustments { get; private set; } = new List<TextAdjustment>();
+        public List<TextAdjustment> GameObjectAdjustments { get; private set; } = new List<TextAdjustment>();
         private readonly List<TextAdjustment> driftTrackedAdjustments = new List<TextAdjustment>();
+        private readonly List<TextAdjustment> goAdjustmentsActive = new List<TextAdjustment>();
 
         public LocalizationConfig()
         {
@@ -76,7 +78,9 @@ namespace MWC_Localization_Core
             // Make reload idempotent by resetting previously loaded values.
             FontMappings.Clear();
             TextAdjustments.Clear();
+            GameObjectAdjustments.Clear();
             driftTrackedAdjustments.Clear();
+            goAdjustmentsActive.Clear();
             LanguageName = "Unknown";
             LanguageCode = "en-US";
 
@@ -132,7 +136,7 @@ namespace MWC_Localization_Core
 
                 CoreConsole.Print($"[LocalizationConfig] Configuration loaded: {LanguageName} ({LanguageCode})");
                 CoreConsole.Print($"[LocalizationConfig] Font mappings: {FontMappings.Count}");
-                CoreConsole.Print($"[LocalizationConfig] Position adjustments: {TextAdjustments.Count}");
+                CoreConsole.Print($"[LocalizationConfig] Position adjustments: {TextAdjustments.Count} TextMesh, {GameObjectAdjustments.Count} GameObject");
 
                 return true;
             }
@@ -244,7 +248,10 @@ namespace MWC_Localization_Core
                 }
 
                 TextAdjustment adjustment = new TextAdjustment(conditionsString, offset, fontSize, lineSpacing, widthScale);
-                TextAdjustments.Add(adjustment);
+                if (adjustment.TargetsGameObject)
+                    GameObjectAdjustments.Add(adjustment);
+                else
+                    TextAdjustments.Add(adjustment);
             }
             catch (System.Exception ex)
             {
@@ -288,8 +295,39 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
-        /// Re-pin drift-tracked TextMeshes whose transform was rewritten by the game
-        /// since the last frame. Called every LateUpdate by the monitor.
+        /// Find each GameObjectEquals adjustment's target and apply its offset.
+        /// Call after TranslateScene / InitialPass on each scene load and F8 reload.
+        /// </summary>
+        public void ApplyGameObjectAdjustments()
+        {
+            for (int i = 0; i < GameObjectAdjustments.Count; i++)
+            {
+                TextAdjustment adj = GameObjectAdjustments[i];
+                for (int j = 0; j < adj.Conditions.Count; j++)
+                {
+                    PathCondition cond = adj.Conditions[j];
+                    if (cond.Type != ConditionType.GameObjectEquals || cond.Negate)
+                        continue;
+
+                    GameObject go = LocalizationUtils.FindGameObjectIncludingInactive(cond.Value);
+                    if (go == null)
+                    {
+                        CoreConsole.Print($"[LocalizationConfig] GameObjectEquals: '{cond.Value}' not present in this scene, skipping");
+                        continue;
+                    }
+
+                    bool applied = adj.ApplyToGameObject(go);
+                    if (applied && adj.HasTrackedGameObjects && !goAdjustmentsActive.Contains(adj))
+                        goAdjustmentsActive.Add(adj);
+
+                    break; // one lookup per rule is sufficient
+                }
+            }
+        }
+
+        /// <summary>
+        /// Re-pin drift-tracked TextMeshes and GameObjects whose transform was rewritten
+        /// by the game since the last frame. Called every LateUpdate by the monitor.
         /// </summary>
         public void RefreshDriftTrackedAdjustments()
         {
@@ -301,20 +339,31 @@ namespace MWC_Localization_Core
                 if (!adjustment.HasDriftTrackedMeshes)
                     driftTrackedAdjustments.RemoveAt(i);
             }
+
+            for (int i = goAdjustmentsActive.Count - 1; i >= 0; i--)
+            {
+                TextAdjustment adjustment = goAdjustmentsActive[i];
+                adjustment.RefreshGameObject();
+
+                if (!adjustment.HasTrackedGameObjects)
+                    goAdjustmentsActive.RemoveAt(i);
+            }
         }
 
         /// <summary>
-        /// Clear all position adjustment caches
-        /// Useful for F8 reload functionality to reapply adjustments
+        /// Clear all position adjustment caches.
+        /// Useful for F8 reload functionality to reapply adjustments.
         /// </summary>
         public void ClearTextAdjustmentCaches()
         {
             driftTrackedAdjustments.Clear();
+            goAdjustmentsActive.Clear();
 
             foreach (TextAdjustment adjustment in TextAdjustments)
-            {
                 adjustment.ClearCache();
-            }
+
+            foreach (TextAdjustment adjustment in GameObjectAdjustments)
+                adjustment.ClearCache();
         }
     }
 }

--- a/LocalizationConfig.cs
+++ b/LocalizationConfig.cs
@@ -63,9 +63,6 @@ namespace MWC_Localization_Core
         public Dictionary<string, string> FontMappings { get; private set; } = new Dictionary<string, string>();
         public List<TextAdjustment> TextAdjustments { get; private set; } = new List<TextAdjustment>();
         public List<TextAdjustment> GameObjectAdjustments { get; private set; } = new List<TextAdjustment>();
-        private readonly List<TextAdjustment> driftTrackedAdjustments = new List<TextAdjustment>();
-        private readonly List<TextAdjustment> goAdjustmentsActive = new List<TextAdjustment>();
-
         public LocalizationConfig()
         {
         }
@@ -79,8 +76,6 @@ namespace MWC_Localization_Core
             FontMappings.Clear();
             TextAdjustments.Clear();
             GameObjectAdjustments.Clear();
-            driftTrackedAdjustments.Clear();
-            goAdjustmentsActive.Clear();
             LanguageName = "Unknown";
             LanguageCode = "en-US";
 
@@ -283,11 +278,7 @@ namespace MWC_Localization_Core
             {
                 if (adjustment.Matches(path))
                 {
-                    bool applied = adjustment.ApplyAdjustment(textMesh, path);
-                    if (applied && adjustment.HasDriftTrackedMeshes && !driftTrackedAdjustments.Contains(adjustment))
-                        driftTrackedAdjustments.Add(adjustment);
-
-                    return applied;
+                    return adjustment.ApplyAdjustment(textMesh);
                 }
             }
 
@@ -316,37 +307,9 @@ namespace MWC_Localization_Core
                         continue;
                     }
 
-                    bool applied = adj.ApplyToGameObject(go);
-                    if (applied && adj.HasTrackedGameObjects && !goAdjustmentsActive.Contains(adj))
-                        goAdjustmentsActive.Add(adj);
-
+                    adj.ApplyToGameObject(go);
                     break; // one lookup per rule is sufficient
                 }
-            }
-        }
-
-        /// <summary>
-        /// Re-pin drift-tracked TextMeshes and GameObjects whose transform was rewritten
-        /// by the game since the last frame. Called every LateUpdate by the monitor.
-        /// </summary>
-        public void RefreshDriftTrackedAdjustments()
-        {
-            for (int i = driftTrackedAdjustments.Count - 1; i >= 0; i--)
-            {
-                TextAdjustment adjustment = driftTrackedAdjustments[i];
-                adjustment.Refresh();
-
-                if (!adjustment.HasDriftTrackedMeshes)
-                    driftTrackedAdjustments.RemoveAt(i);
-            }
-
-            for (int i = goAdjustmentsActive.Count - 1; i >= 0; i--)
-            {
-                TextAdjustment adjustment = goAdjustmentsActive[i];
-                adjustment.RefreshGameObject();
-
-                if (!adjustment.HasTrackedGameObjects)
-                    goAdjustmentsActive.RemoveAt(i);
             }
         }
 
@@ -356,9 +319,6 @@ namespace MWC_Localization_Core
         /// </summary>
         public void ClearTextAdjustmentCaches()
         {
-            driftTrackedAdjustments.Clear();
-            goAdjustmentsActive.Clear();
-
             foreach (TextAdjustment adjustment in TextAdjustments)
                 adjustment.ClearCache();
 

--- a/LocalizationUtils.cs
+++ b/LocalizationUtils.cs
@@ -116,6 +116,38 @@ namespace MWC_Localization_Core
         }
 
         /// <summary>
+        /// Like FindGameObjectCached but also searches inactive GameObjects.
+        /// Falls back to Resources.FindObjectsOfTypeAll when the active-only
+        /// GameObject.Find misses. The result is cached for future calls.
+        /// </summary>
+        public static GameObject FindGameObjectIncludingInactive(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            GameObject found = FindGameObjectCached(path);
+            if (found != null)
+                return found;
+
+            // Pre-filter by leaf name before building full paths.
+            string leafName = path.Substring(path.LastIndexOf('/') + 1);
+            Transform[] all = Resources.FindObjectsOfTypeAll<Transform>();
+            for (int i = 0; i < all.Length; i++)
+            {
+                Transform t = all[i];
+                if (t == null || t.name != leafName)
+                    continue;
+                if (GetGameObjectPath(t.gameObject) == path)
+                {
+                    gameObjectFindCache[path] = t.gameObject;
+                    return t.gameObject;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Shared accessor for all TextMeshes including inactive ones.
         /// </summary>
         public static TextMesh[] GetAllTextMeshesIncludingInactive()

--- a/LocalizationUtils.cs
+++ b/LocalizationUtils.cs
@@ -39,6 +39,8 @@ namespace MWC_Localization_Core
         private static Dictionary<GameObject, string> pathCache = new Dictionary<GameObject, string>();
         // Cache for expensive GameObject.Find(path) lookups
         private static Dictionary<string, GameObject> gameObjectFindCache = new Dictionary<string, GameObject>();
+        // Paths confirmed absent after a full inactive-object scan; cleared on scene change / F8.
+        private static HashSet<string> notFoundPaths = new HashSet<string>();
 
         // Reusable scratch buffers for path construction. Unity is single-threaded so no locking needed.
         private static Transform[] pathChain = new Transform[32];
@@ -129,6 +131,10 @@ namespace MWC_Localization_Core
             if (found != null)
                 return found;
 
+            // Skip the expensive scan if a previous call already confirmed this path absent.
+            if (notFoundPaths.Contains(path))
+                return null;
+
             // Pre-filter by leaf name before building full paths.
             string leafName = path.Substring(path.LastIndexOf('/') + 1);
             Transform[] all = Resources.FindObjectsOfTypeAll<Transform>();
@@ -144,6 +150,7 @@ namespace MWC_Localization_Core
                 }
             }
 
+            notFoundPaths.Add(path);
             return null;
         }
 
@@ -163,6 +170,7 @@ namespace MWC_Localization_Core
         {
             pathCache.Clear();
             gameObjectFindCache.Clear();
+            notFoundPaths.Clear();
         }
 
         /// <summary>
@@ -202,6 +210,9 @@ namespace MWC_Localization_Core
                 for (int i = 0; i < staleFindKeys.Count; i++)
                     gameObjectFindCache.Remove(staleFindKeys[i]);
             }
+
+            // A path absent in one scene may exist in the next; always reset on scene change.
+            notFoundPaths.Clear();
         }
     }
 

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -120,6 +120,7 @@ namespace MWC_Localization_Core
             TranslateScene();
             MarkSceneTranslated("MainMenu");
             RunSurfaceInitialPasses(null);
+            config.ApplyGameObjectAdjustments();
         }
 
         private void Mod_PostLoad()
@@ -128,6 +129,7 @@ namespace MWC_Localization_Core
             TranslateScene();
             MarkSceneTranslated("GAME");
             RunSurfaceInitialPasses(null);
+            config.ApplyGameObjectAdjustments();
 
             // ALL continuous monitoring runs in LateUpdate to get correct timing relative to game updates.
             lateUpdateHandlerObject = new GameObject("MWC_LateUpdateHandler");
@@ -182,6 +184,7 @@ namespace MWC_Localization_Core
                 TranslateScene();
                 MarkSceneTranslated("MainMenu");
                 RunSurfaceInitialPasses(null);
+                config.ApplyGameObjectAdjustments();
             }
             else if (sceneName == "GAME" && ShouldTranslateScene("GAME"))
             {
@@ -189,6 +192,7 @@ namespace MWC_Localization_Core
                 TranslateScene();
                 MarkSceneTranslated("GAME");
                 RunSurfaceInitialPasses("Initial ");
+                config.ApplyGameObjectAdjustments();
             }
         }
 
@@ -350,6 +354,7 @@ namespace MWC_Localization_Core
                 currentScene = sceneName;
                 MarkSceneTranslated(sceneName);
                 RunSurfaceInitialPasses("Reload ");
+                config.ApplyGameObjectAdjustments();
             }
 
             // Restart LateUpdate driver with the new surface list (instance hasn't changed but its tick state has)

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -134,7 +134,7 @@ namespace MWC_Localization_Core
             // ALL continuous monitoring runs in LateUpdate to get correct timing relative to game updates.
             lateUpdateHandlerObject = new GameObject("MWC_LateUpdateHandler");
             lateUpdateHandler = lateUpdateHandlerObject.AddComponent<LateUpdateHandler>();
-            lateUpdateHandler.Initialize(surfaces, config, () => HasSceneBeenTranslated("GAME"));
+            lateUpdateHandler.Initialize(surfaces, () => HasSceneBeenTranslated("GAME"));
         }
 
         private void Mod_Update()
@@ -361,7 +361,7 @@ namespace MWC_Localization_Core
             if (lateUpdateHandler != null)
             {
                 lateUpdateHandler.ClearCache();
-                lateUpdateHandler.Initialize(surfaces, config, () => HasSceneBeenTranslated("GAME"));
+                lateUpdateHandler.Initialize(surfaces, () => HasSceneBeenTranslated("GAME"));
             }
 
             CoreConsole.Print($"[{Name}] [F8] Reloaded {translations.Count} translations. Reapplied fonts/adjustments to {reappliedCount} TextMeshes.");

--- a/TextAdjustment.cs
+++ b/TextAdjustment.cs
@@ -75,6 +75,24 @@ namespace MWC_Localization_Core
             get { return lastAppliedLocalPositions.Count > 0; }
         }
 
+        /// <summary>
+        /// True when any condition is GameObjectEquals — the adjustment targets a parent
+        /// GameObject transform rather than individual TextMesh components.
+        /// Set automatically during ParseConditions.
+        /// </summary>
+        internal bool TargetsGameObject { get; private set; }
+
+        // Track adjusted GameObjects and their pinned positions for drift refresh.
+        private readonly Dictionary<GameObject, Vector3> originalGOPositions = new Dictionary<GameObject, Vector3>();
+        private readonly Dictionary<GameObject, Vector3> lastAppliedGOPositions = new Dictionary<GameObject, Vector3>();
+        private readonly List<GameObject> goRefreshSnapshot = new List<GameObject>();
+        private readonly List<GameObject> goStaleBuffer = new List<GameObject>();
+
+        public bool HasTrackedGameObjects
+        {
+            get { return lastAppliedGOPositions.Count > 0; }
+        }
+
         public TextAdjustment(string conditionsString, Vector3 offset, float? fontSize = null, float? lineSpacing = null, float? widthScale = null)
         {
             Offset = offset;
@@ -82,6 +100,69 @@ namespace MWC_Localization_Core
             LineSpacing = lineSpacing;
             WidthScale = widthScale;
             ParseConditions(conditionsString);
+        }
+
+        /// <summary>
+        /// Apply position offset to a parent GameObject. No-op if already applied.
+        /// Only uses the Offset; FontSize/LineSpacing/WidthScale are TextMesh-specific.
+        /// </summary>
+        /// <returns>True if the adjustment was applied</returns>
+        public bool ApplyToGameObject(GameObject go)
+        {
+            if (go == null)
+                return false;
+
+            if (lastAppliedGOPositions.ContainsKey(go))
+                return false;
+
+            if (!originalGOPositions.ContainsKey(go))
+                originalGOPositions[go] = go.transform.localPosition;
+
+            Vector3 newPos = go.transform.localPosition + Offset;
+            go.transform.localPosition = newPos;
+            lastAppliedGOPositions[go] = newPos;
+            return true;
+        }
+
+        /// <summary>
+        /// Re-pin drift-tracked GameObjects whose local position the game has rewritten.
+        /// Called every LateUpdate via LocalizationConfig. No-op when nothing is tracked.
+        /// </summary>
+        public void RefreshGameObject()
+        {
+            if (lastAppliedGOPositions.Count == 0)
+                return;
+
+            goRefreshSnapshot.Clear();
+            goRefreshSnapshot.AddRange(lastAppliedGOPositions.Keys);
+            goStaleBuffer.Clear();
+
+            foreach (GameObject go in goRefreshSnapshot)
+            {
+                if (go == null)
+                {
+                    goStaleBuffer.Add(go);
+                    continue;
+                }
+
+                Vector3 currentPos = go.transform.localPosition;
+                Vector3 lastApplied = lastAppliedGOPositions[go];
+                if ((currentPos - lastApplied).sqrMagnitude <= PositionToleranceSqr)
+                    continue;
+
+                Vector3 newPos = currentPos + Offset;
+                go.transform.localPosition = newPos;
+                lastAppliedGOPositions[go] = newPos;
+                originalGOPositions[go] = currentPos;
+            }
+
+            goRefreshSnapshot.Clear();
+
+            for (int i = 0; i < goStaleBuffer.Count; i++)
+            {
+                lastAppliedGOPositions.Remove(goStaleBuffer[i]);
+                originalGOPositions.Remove(goStaleBuffer[i]);
+            }
         }
 
         /// <summary>
@@ -235,6 +316,15 @@ namespace MWC_Localization_Core
             // adjustedTextMeshes is already cleared by RestoreOriginal() calls
             originalStates.Clear();
             lastAppliedLocalPositions.Clear();
+
+            // Restore adjusted GameObjects
+            foreach (var go in new List<GameObject>(originalGOPositions.Keys))
+            {
+                if (go != null)
+                    go.transform.localPosition = originalGOPositions[go];
+            }
+            originalGOPositions.Clear();
+            lastAppliedGOPositions.Clear();
         }
 
         /// <summary>
@@ -276,6 +366,12 @@ namespace MWC_Localization_Core
                 {
                     string value = trimmed.Substring(7, trimmed.Length - 8);
                     Conditions.Add(new PathCondition(ConditionType.Equals, value, negate));
+                }
+                else if (trimmed.StartsWith("GameObjectEquals(") && trimmed.EndsWith(")"))
+                {
+                    string value = trimmed.Substring(17, trimmed.Length - 18);
+                    Conditions.Add(new PathCondition(ConditionType.GameObjectEquals, value, negate));
+                    TargetsGameObject = true;
                 }
             }
         }
@@ -338,6 +434,10 @@ namespace MWC_Localization_Core
                 case ConditionType.Equals:
                     result = path == Value;
                     break;
+
+                case ConditionType.GameObjectEquals:
+                    result = path == Value;
+                    break;
             }
 
             // Apply negation if needed
@@ -353,6 +453,11 @@ namespace MWC_Localization_Core
         Contains,
         EndsWith,
         StartsWith,
-        Equals
+        Equals,
+        /// <summary>
+        /// Targets a parent GameObject by exact path instead of a TextMesh.
+        /// Adjustments applied via this type go to the GameObject transform directly.
+        /// </summary>
+        GameObjectEquals
     }
 }

--- a/TextAdjustment.cs
+++ b/TextAdjustment.cs
@@ -28,28 +28,6 @@ namespace MWC_Localization_Core
     /// </summary>
     public class TextAdjustment
     {
-        // Paths whose transforms the game rewrites repeatedly. TextMeshes whose path
-        // matches any entry opt into drift refresh after a normal adjustment applies.
-        // Keep this list small - every touched TextMesh is checked during LateUpdate.
-        internal static readonly string[] DriftTrackedPathPatterns =
-        {
-            "Sheets/Magazine/Products",
-        };
-
-        private const float PositionToleranceSqr = 1e-7f;
-
-        internal static bool IsDriftTrackedPath(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-                return false;
-            for (int i = 0; i < DriftTrackedPathPatterns.Length; i++)
-            {
-                if (path.Contains(DriftTrackedPathPatterns[i]))
-                    return true;
-            }
-            return false;
-        }
-
         public List<PathCondition> Conditions { get; private set; } = new List<PathCondition>();
         public Vector3 Offset { get; private set; }
         public float? FontSize { get; private set; }
@@ -62,19 +40,6 @@ namespace MWC_Localization_Core
         // Store original state of adjusted TextMesh objects for restoration
         private Dictionary<TextMesh, OriginalTextMeshState> originalStates = new Dictionary<TextMesh, OriginalTextMeshState>();
 
-        // Last position written by this rule, for drift-tracked TextMeshes only.
-        // Presence in this dict is the marker that a mesh participates in Refresh().
-        private Dictionary<TextMesh, Vector3> lastAppliedLocalPositions = new Dictionary<TextMesh, Vector3>();
-
-        // Pre-allocated buffers for Refresh(); avoids per-frame heap allocation.
-        private readonly List<TextMesh> refreshSnapshot = new List<TextMesh>();
-        private readonly List<TextMesh> staleBuffer = new List<TextMesh>();
-
-        public bool HasDriftTrackedMeshes
-        {
-            get { return lastAppliedLocalPositions.Count > 0; }
-        }
-
         /// <summary>
         /// True when any condition is GameObjectEquals — the adjustment targets a parent
         /// GameObject transform rather than individual TextMesh components.
@@ -82,16 +47,7 @@ namespace MWC_Localization_Core
         /// </summary>
         internal bool TargetsGameObject { get; private set; }
 
-        // Track adjusted GameObjects and their pinned positions for drift refresh.
         private readonly Dictionary<GameObject, Vector3> originalGOPositions = new Dictionary<GameObject, Vector3>();
-        private readonly Dictionary<GameObject, Vector3> lastAppliedGOPositions = new Dictionary<GameObject, Vector3>();
-        private readonly List<GameObject> goRefreshSnapshot = new List<GameObject>();
-        private readonly List<GameObject> goStaleBuffer = new List<GameObject>();
-
-        public bool HasTrackedGameObjects
-        {
-            get { return lastAppliedGOPositions.Count > 0; }
-        }
 
         public TextAdjustment(string conditionsString, Vector3 offset, float? fontSize = null, float? lineSpacing = null, float? widthScale = null)
         {
@@ -109,60 +65,12 @@ namespace MWC_Localization_Core
         /// <returns>True if the adjustment was applied</returns>
         public bool ApplyToGameObject(GameObject go)
         {
-            if (go == null)
+            if (go == null || originalGOPositions.ContainsKey(go))
                 return false;
 
-            if (lastAppliedGOPositions.ContainsKey(go))
-                return false;
-
-            if (!originalGOPositions.ContainsKey(go))
-                originalGOPositions[go] = go.transform.localPosition;
-
-            Vector3 newPos = go.transform.localPosition + Offset;
-            go.transform.localPosition = newPos;
-            lastAppliedGOPositions[go] = newPos;
+            originalGOPositions[go] = go.transform.localPosition;
+            go.transform.localPosition += Offset;
             return true;
-        }
-
-        /// <summary>
-        /// Re-pin drift-tracked GameObjects whose local position the game has rewritten.
-        /// Called every LateUpdate via LocalizationConfig. No-op when nothing is tracked.
-        /// </summary>
-        public void RefreshGameObject()
-        {
-            if (lastAppliedGOPositions.Count == 0)
-                return;
-
-            goRefreshSnapshot.Clear();
-            goRefreshSnapshot.AddRange(lastAppliedGOPositions.Keys);
-            goStaleBuffer.Clear();
-
-            foreach (GameObject go in goRefreshSnapshot)
-            {
-                if (go == null)
-                {
-                    goStaleBuffer.Add(go);
-                    continue;
-                }
-
-                Vector3 currentPos = go.transform.localPosition;
-                Vector3 lastApplied = lastAppliedGOPositions[go];
-                if ((currentPos - lastApplied).sqrMagnitude <= PositionToleranceSqr)
-                    continue;
-
-                Vector3 newPos = currentPos + Offset;
-                go.transform.localPosition = newPos;
-                lastAppliedGOPositions[go] = newPos;
-                originalGOPositions[go] = currentPos;
-            }
-
-            goRefreshSnapshot.Clear();
-
-            for (int i = 0; i < goStaleBuffer.Count; i++)
-            {
-                lastAppliedGOPositions.Remove(goStaleBuffer[i]);
-                originalGOPositions.Remove(goStaleBuffer[i]);
-            }
         }
 
         /// <summary>
@@ -170,7 +78,7 @@ namespace MWC_Localization_Core
         /// Uses HashSet to prevent duplicate adjustments
         /// </summary>
         /// <returns>True if adjustment was applied, false if already adjusted</returns>
-        public bool ApplyAdjustment(TextMesh textMesh, string path)
+        public bool ApplyAdjustment(TextMesh textMesh)
         {
             if (textMesh == null)
                 return false;
@@ -214,64 +122,7 @@ namespace MWC_Localization_Core
             // Mark as adjusted
             adjustedTextMeshes.Add(textMesh);
 
-            // Opt this mesh into Refresh() only if its path is on the drift-tracked whitelist.
-            if (IsDriftTrackedPath(path))
-                lastAppliedLocalPositions[textMesh] = newPosition;
-
             return true;
-        }
-
-        /// <summary>
-        /// Re-pin drift-tracked TextMeshes whose local position the game has rewritten
-        /// since the last frame. Caller invokes every LateUpdate. No-op when nothing is tracked.
-        /// </summary>
-        public void Refresh()
-        {
-            if (lastAppliedLocalPositions.Count == 0)
-                return;
-
-            // Snapshot keys into the pre-allocated buffer so we can mutate the dict
-            // during the pass without allocating a new List each frame.
-            refreshSnapshot.Clear();
-            refreshSnapshot.AddRange(lastAppliedLocalPositions.Keys);
-            staleBuffer.Clear();
-
-            foreach (TextMesh tm in refreshSnapshot)
-            {
-                if (tm == null)
-                {
-                    staleBuffer.Add(tm);
-                    continue;
-                }
-
-                Vector3 currentPos = tm.transform.localPosition;
-                Vector3 lastApplied = lastAppliedLocalPositions[tm];
-                if ((currentPos - lastApplied).sqrMagnitude <= PositionToleranceSqr)
-                    continue;
-
-                // Game wrote a new local position. Treat it as the new baseline so we
-                // don't accumulate drift, then re-apply the offset.
-                OriginalTextMeshState state;
-                if (originalStates.TryGetValue(tm, out state))
-                {
-                    state.LocalPosition = currentPos;
-                    originalStates[tm] = state;
-                }
-
-                Vector3 newPos = currentPos + Offset;
-                tm.transform.localPosition = newPos;
-                lastAppliedLocalPositions[tm] = newPos;
-            }
-
-            // Release snapshot refs promptly so Unity can manage TextMesh lifetime.
-            refreshSnapshot.Clear();
-
-            for (int i = 0; i < staleBuffer.Count; i++)
-            {
-                lastAppliedLocalPositions.Remove(staleBuffer[i]);
-                originalStates.Remove(staleBuffer[i]);
-                adjustedTextMeshes.Remove(staleBuffer[i]);
-            }
         }
 
         /// <summary>
@@ -296,7 +147,6 @@ namespace MWC_Localization_Core
 
             // Remove from adjusted set so it can be re-adjusted
             adjustedTextMeshes.Remove(textMesh);
-            lastAppliedLocalPositions.Remove(textMesh);
 
             return true;
         }
@@ -315,7 +165,6 @@ namespace MWC_Localization_Core
             }
             // adjustedTextMeshes is already cleared by RestoreOriginal() calls
             originalStates.Clear();
-            lastAppliedLocalPositions.Clear();
 
             // Restore adjusted GameObjects
             foreach (var go in new List<GameObject>(originalGOPositions.Keys))
@@ -324,7 +173,6 @@ namespace MWC_Localization_Core
                     go.transform.localPosition = originalGOPositions[go];
             }
             originalGOPositions.Clear();
-            lastAppliedGOPositions.Clear();
         }
 
         /// <summary>

--- a/TextMeshTranslator.cs
+++ b/TextMeshTranslator.cs
@@ -196,8 +196,7 @@ namespace MWC_Localization_Core
             }
 
             // Already-localized text still needs its font + adjustments applied so
-            // one-shot monitors can stop cleanly and so drift-tracked meshes get
-            // entered into lastAppliedLocalPositions on first contact.
+            // one-shot monitors can stop cleanly.
             if (!forceUpdate && currentText == translation)
             {
                 ApplyCustomFont(textMesh, path);

--- a/dist/Assets/MWC_Localization_Core/config.txt
+++ b/dist/Assets/MWC_Localization_Core/config.txt
@@ -71,3 +71,8 @@ Contains(COMPUTER/SYSTEM/TELEBBS/Software) & EndsWith(/text 2) = 0,0,0,2,
 Contains(COMPUTER/SYSTEM/TELEBBS/Software) & EndsWith(/BaudRate) = 0,0,0,2,
 Contains(COMPUTER/SYSTEM/TELEBBS/Software) & EndsWith(/StatusBar) = 0,0,0,2,
 Contains(COMPUTER/SYSTEM/TELEBBS/CONLINE) = 0,0,0,2,
+## Parts Magazine Product List
+## - Adjust font size via 'Sheets/Magazine/Products'
+## - Adjust X/Y/Z offset via 'Sheets/Magazine/List'
+Contains(Sheets/Magazine/Products) = 0,0,0,0.0024
+GameObjectEquals(Sheets/Magazine/List) = 0,-0.002,0


### PR DESCRIPTION
This PR introduces **GameObject-level position adjustment support** for TextMesh positioning and removes obsolete drift-tracking logic that is no longer needed.

## Problem

TextMeshes under `Sheets/Magazine/Products` were moved to `Sheets/Magazine/List`, causing position adjustments to be lost. Rather than updating individual TextMesh paths, this change enables position adjustments at the parent GameObject level.

## Changes

- Added `GameObjectEquals` targeting in the `TextAdjustment` class to support matching and adjusting GameObject-level transformations
- Extended position adjustment syntax in `config.txt` to allow specifying parent GameObjects as adjustment targets
- Removed obsolete drift-tracking logic that was previously used as a workaround in #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Position and font adjustments can now target whole GameObjects as well as TextMesh components.
  * Scene object lookup now finds inactive GameObjects.

* **Changes**
  * Removed the drift-tracked path refresh system; adjustments are applied directly.
  * Late-update processing now gates on scene readiness and applies game-object adjustments during menu/loading and reload flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potatosalad775/MWC_Localization_Core/pull/89)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->