### PR TITLE
Fix rally class FSM source translation

### DIFF
--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -140,7 +140,6 @@ namespace MWC_Localization_Core
                 changed |= TryApplyFleetariServicePaymentBreakdownSource();
                 changed |= TryApplyAtmTransactionDescriptionSource();
                 changed |= TryApplyTvChatDaySource();
-                changed |= TryApplyRallyClassSources();
                 changed |= TryApplyGameTeletextWeatherUpdaterDirectTranslations();
             }
 
@@ -735,6 +734,14 @@ namespace MWC_Localization_Core
             changed |= TryApplyRallyClassSource(rallyPlayerResultsTarget, "State 1", 5);
             changed |= TryApplyRallyClassSource(rallyRegistrationClassTarget, "State 1", 3);
             return changed;
+        }
+
+        internal bool ApplyRallyClassSourcesForCurrentScene()
+        {
+            if (Application.loadedLevelName != "GAME")
+                return false;
+
+            return TryApplyRallyClassSources();
         }
 
         private bool TryApplyRallyClassSource(FsmTarget target, string stateName, int actionIndex)
@@ -1726,6 +1733,47 @@ namespace MWC_Localization_Core
             resolvedTargets.Clear();
             warnedTargets.Clear();
             initializedFsmIds.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Targeted per-frame repair for rally class labels. This keeps the broad FSM
+    /// hook on its normal cadence while catching the exact frame where the sheet
+    /// rebuilds the visible rally class text.
+    /// </summary>
+    public class RallyClassTextHook : ITranslationSurface
+    {
+        public string Name { get { return "RallyClassTextHook"; } }
+        public SurfaceCadence Cadence { get { return SurfaceCadence.PerFrame; } }
+        public bool IsComplete { get { return false; } }
+
+        private readonly FsmTextHook fsmTextHook;
+
+        public RallyClassTextHook(FsmTextHook fsmTextHook)
+        {
+            this.fsmTextHook = fsmTextHook;
+        }
+
+        public void Initialize(TranslationContext ctx)
+        {
+        }
+
+        public int InitialPass()
+        {
+            return MonitorTick(0f);
+        }
+
+        public int MonitorTick(float deltaTime)
+        {
+            return fsmTextHook != null && fsmTextHook.ApplyRallyClassSourcesForCurrentScene() ? 1 : 0;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public void ClearTranslations()
+        {
         }
     }
 }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -102,6 +102,7 @@ namespace MWC_Localization_Core
             // TeletextChatHandler reads chat translation data from TeletextHandler, so it
             // takes a reference to the shared instance.
             var teletext = new TeletextHandler();
+            var fsmTextHook = new FsmTextHook();
             surfaces = new List<ITranslationSurface>
             {
                 new GuiTextMonitor(),
@@ -110,7 +111,8 @@ namespace MWC_Localization_Core
                 new TeletextChatHandler(teletext),
                 new ArrayListProxyHandler(),
                 new HashTableProxyHandler(),
-                new FsmTextHook(),
+                fsmTextHook,
+                new RallyClassTextHook(fsmTextHook),
             };
 
             for (int i = 0; i < surfaces.Count; i++)


### PR DESCRIPTION
## Rally class source translation

The rally class text is generated by PlayMaker FSM actions before it is written to the visible sheet text.

For the rally result sheet, the game builds the class line through the `Sheets/RallyResults/PlayerResults` FSM. Instead of translating the final `TextMesh` after it appears on screen, the hook now patches the FSM source action that provides the class text. This keeps the generated sheet output closer to how the game builds it internally.

The same approach is used for the rally registration class text under `Sheets/RallyRegistration/Functions/Class`.

## What changed

- Added a focused rally class translation surface that runs only the rally class source repair.
- Kept the broad `FsmTextHook` cadence unchanged, avoiding wider dynamic FSM polling.
- Changed rally class handling to translate the FSM source action directly instead of post-processing the visible `TextMesh`.
- Preserved the discovered state/action targets currently used by the game:
  - `Sheets/RallyResults/PlayerResults` -> `Data` -> `State 1` -> action `5`
  - `Sheets/RallyRegistration/Functions/Class` -> `Data` -> `State 1` -> action `3`
- Translation values still come from the normal translation files, so language packs can keep controlling `Junior`, `Amateur`, and `- Class` without hardcoded translated text in code.

## Why

The previous visible-text fallback could still allow a short untranslated frame when the sheet rebuilt its text. Applying the translation at the FSM source level makes the rally class line get generated with the translated parts already in place, matching the style used by the ExtraTranslate implementation while keeping the hook scoped to these rally sheet paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved translation text handling with enhanced per-frame processing for more reliable in-game text updates across different game scenes
  * Streamlined translation surface architecture for better management of text sources during gameplay

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potatosalad775/MWC_Localization_Core/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->