### PR TITLE
Fix and isolate Yellow Pages magazine translation handling

### DIFF
--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -20,6 +20,7 @@ namespace MWC_Localization_Core
 
         // Reference to main translation dictionary (from Plugin)
         private TranslationDictionary mainTranslations;
+        private TranslationDictionary magazineTranslations;
         private TextMeshTranslator translator;
         
         // Config: List of array paths to translate (path:index)
@@ -46,6 +47,7 @@ namespace MWC_Localization_Core
         public void Initialize(TranslationContext ctx)
         {
             mainTranslations = ctx.Translations;
+            magazineTranslations = ctx.MagazineTranslations;
             translator = ctx.Translator;
             InitializeArrayPaths();
         }
@@ -199,7 +201,7 @@ namespace MWC_Localization_Core
             // GameObject is inactive, so when PlayMaker prefills the runtime arrayList
             // on activation it copies already-translated strings instead of the
             // original text - removing the visible original-then-translated flip.
-            translatedCount += TranslatePreFillStringList(proxy);
+            translatedCount += TranslatePreFillStringList(proxy, arrayKey);
 
             ArrayList arrayList = proxy.arrayList;
 
@@ -216,7 +218,7 @@ namespace MWC_Localization_Core
                 if (string.IsNullOrEmpty(original))
                     continue;
 
-                string translation = FindTranslation(original);
+                string translation = FindTranslation(original, arrayKey);
                 if (translation != null)
                 {
                     arrayList[i] = translation;
@@ -270,7 +272,7 @@ namespace MWC_Localization_Core
         }
 
         // Translate a proxy's serialized prefill list in place. Returns count translated.
-        private int TranslatePreFillStringList(PlayMakerArrayListProxy proxy)
+        private int TranslatePreFillStringList(PlayMakerArrayListProxy proxy, string arrayKey)
         {
             List<string> preFill = proxy.preFillStringList;
             if (preFill == null || preFill.Count == 0)
@@ -283,7 +285,7 @@ namespace MWC_Localization_Core
                 if (string.IsNullOrEmpty(original))
                     continue;
 
-                string translation = FindTranslation(original);
+                string translation = FindTranslation(original, arrayKey);
                 if (translation != null)
                 {
                     preFill[i] = translation;
@@ -294,14 +296,26 @@ namespace MWC_Localization_Core
             return translatedCount;
         }
 
-        // Find translation from the shared dictionary. Magazine entries are loaded
-        // into it by the main class compatibility shim.
-        private string FindTranslation(string original)
+        private string FindTranslation(string original, string arrayKey)
         {
-            if (mainTranslations.TryGetExact(original, out string translation))
+            string translation;
+            if (IsMagazineArray(arrayKey)
+                && magazineTranslations != null
+                && magazineTranslations.TryGetExact(original, out translation))
+            {
+                return translation;
+            }
+
+            if (mainTranslations != null && mainTranslations.TryGetExact(original, out translation))
                 return translation;
 
             return null;
+        }
+
+        private static bool IsMagazineArray(string arrayKey)
+        {
+            return !string.IsNullOrEmpty(arrayKey)
+                && arrayKey.StartsWith("CARPARTS/PARTSYSTEM/PostSystem/", System.StringComparison.Ordinal);
         }
 
         // Apply localized fonts to TextMesh components displaying array data

--- a/ArrayListProxyHandler.cs
+++ b/ArrayListProxyHandler.cs
@@ -19,8 +19,7 @@ namespace MWC_Localization_Core
         }
 
         // Reference to main translation dictionary (from Plugin)
-        private TranslationDictionary mainTranslations;
-        private TranslationDictionary magazineTranslations;
+        private TranslationContext translationContext;
         private TextMeshTranslator translator;
         
         // Config: List of array paths to translate (path:index)
@@ -46,8 +45,7 @@ namespace MWC_Localization_Core
 
         public void Initialize(TranslationContext ctx)
         {
-            mainTranslations = ctx.Translations;
-            magazineTranslations = ctx.MagazineTranslations;
+            translationContext = ctx;
             translator = ctx.Translator;
             InitializeArrayPaths();
         }
@@ -298,18 +296,20 @@ namespace MWC_Localization_Core
 
         private string FindTranslation(string original, string arrayKey)
         {
+            if (translationContext == null)
+                return null;
+
             string translation;
-            if (IsMagazineArray(arrayKey)
-                && magazineTranslations != null
-                && magazineTranslations.TryGetExact(original, out translation))
+            if (IsMagazineArray(arrayKey))
             {
-                return translation;
+                return translationContext.TryGetMagazine(original, out translation)
+                    ? translation
+                    : null;
             }
 
-            if (mainTranslations != null && mainTranslations.TryGetExact(original, out translation))
-                return translation;
-
-            return null;
+            return translationContext.TryGetGlobal(original, out translation)
+                ? translation
+                : null;
         }
 
         private static bool IsMagazineArray(string arrayKey)

--- a/FsmTextHook.BuiltInTargets.cs
+++ b/FsmTextHook.BuiltInTargets.cs
@@ -12,8 +12,8 @@ namespace MWC_Localization_Core
     {
         private void AddMagazineFormatRules(Dictionary<string, FsmTarget> byKey, string objectPath)
         {
-            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, "h.", magazineTranslations);
-            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, ",- puh.", magazineTranslations);
+            AddMagazineTargetRule(byKey, objectPath, "Generate", "Format", 2, "h.");
+            AddMagazineTargetRule(byKey, objectPath, "Generate", "Format", 2, ",- puh.");
         }
 
         private void AddBuiltInTargets(Dictionary<string, FsmTarget> byKey)

--- a/FsmTextHook.BuiltInTargets.cs
+++ b/FsmTextHook.BuiltInTargets.cs
@@ -12,8 +12,8 @@ namespace MWC_Localization_Core
     {
         private void AddMagazineFormatRules(Dictionary<string, FsmTarget> byKey, string objectPath)
         {
-            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, "h.");
-            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, ",- puh.");
+            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, "h.", magazineTranslations);
+            AddTargetRule(byKey, objectPath, "Generate", "Format", 2, ",- puh.", magazineTranslations);
         }
 
         private void AddBuiltInTargets(Dictionary<string, FsmTarget> byKey)

--- a/FsmTextHook.BuiltInTargets.cs
+++ b/FsmTextHook.BuiltInTargets.cs
@@ -313,27 +313,45 @@ namespace MWC_Localization_Core
             AddTargetRule(byKey, "REPAIRSHOP/Jobs/Springs", "Work", "Cost 2", 2, "Mittatilausjouset / Coil spring order");
 
             // Sheets: Yellow Pages Magazine ad text
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row1/Random/ListRandom10");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row1/Regular/ListRegular10");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row1/Regular/ListRegular03");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row1/Random/ListRandom02");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row2/Random/ListRandom06");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row2/Regular/ListRegular06");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row2/Regular/ListRegular07");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page1/Row2/Regular/ListRegular09");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Regular/ListRegular01");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Regular/ListRegular02");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Random/ListRandom05");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Regular/ListRegular05");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Regular/ListRegular04");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Random/ListRandom03");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row3/Random/ListRandom04");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Random/ListRandom07");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Random/ListRandom01");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Regular/ListRegular08");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Random/ListRandom08");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Random/ListRandom09");
-            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Page2/Row4/Pic/ListPic01");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row1/Random/ListRandom04");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row1/Regular/ListRegular03");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row1/Regular/ListRegular08");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row1/Regular/ListRegular10");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row2/Random/ListRandom06");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row2/Random/ListRandom08");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row2/Regular/ListRegular06");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row2/Regular/ListRegular07");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Left1/Row2/Regular/ListRegular09");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Random/ListRandom03");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Random/ListRandom05");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Regular/ListRegular01");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Regular/ListRegular02");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Regular/ListRegular04");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row3/Regular/ListRegular05");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row4/Pic/ListPic01");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row4/Random/ListRandom01");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row4/Random/ListRandom02");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row4/Random/ListRandom07");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page1/Right1/Row4/Regular/ListRegular11");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row3/Pic/ListPic02");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row3/Random/ListRandom09");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row3/Regular/ListRegular12");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row3/Regular/ListRegular13");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Random/ListRandom10");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Random/ListRandom11");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Random/ListRandom12");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Regular/ListRegular14");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Regular/ListRegular15");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Regular/ListRegular16");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Left2/Row4/Regular/ListRegular17");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row1/Random/ListRandom13");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row1/Regular/ListRegular18");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row1/Regular/ListRegular19");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row1/Regular/ListRegular20");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row2/Regular/ListRegular21");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row2/Regular/ListRegular22");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row2/Regular/ListRegular23");
+            AddMagazineFormatRules(byKey, "Sheets/YellowPagesMagazine/Pages/Page2/Right2/Row2/Regular/ListRegular24");
         }
     }
 }

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -41,6 +41,7 @@ namespace MWC_Localization_Core
 
         private readonly List<FsmTarget> targets = new List<FsmTarget>();
         private TranslationDictionary translations;
+        private TranslationDictionary magazineTranslations;
         private readonly Dictionary<string, string> translationCache = new Dictionary<string, string>();
         private readonly Dictionary<string, List<PlayMakerFSM>> indexedFsmCache = new Dictionary<string, List<PlayMakerFSM>>();
         private readonly Dictionary<string, List<PlayMakerFSM>> fsmListCache = new Dictionary<string, List<PlayMakerFSM>>();
@@ -86,6 +87,7 @@ namespace MWC_Localization_Core
         public void Initialize(TranslationContext ctx)
         {
             this.translations = ctx.Translations;
+            this.magazineTranslations = ctx.MagazineTranslations;
             BuildTargets();
             ResetRuntimeState();
         }
@@ -134,11 +136,16 @@ namespace MWC_Localization_Core
 
         private void AddTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source)
         {
+            AddTargetRule(byKey, objectPath, fsmName, stateName, actionIndex, source, translations);
+        }
+
+        private void AddTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source, TranslationDictionary sourceTranslations)
+        {
             if (byKey == null || string.IsNullOrEmpty(objectPath) || string.IsNullOrEmpty(source))
                 return;
 
             string translation;
-            if (translations == null || !translations.TryGetExact(source, out translation))
+            if (sourceTranslations == null || !sourceTranslations.TryGetExact(source, out translation))
                 return;
 
             string key = BuildKey(objectPath, fsmName, stateName, actionIndex);

--- a/FsmTextHook.cs
+++ b/FsmTextHook.cs
@@ -40,8 +40,7 @@ namespace MWC_Localization_Core
         }
 
         private readonly List<FsmTarget> targets = new List<FsmTarget>();
-        private TranslationDictionary translations;
-        private TranslationDictionary magazineTranslations;
+        private TranslationContext translationContext;
         private readonly Dictionary<string, string> translationCache = new Dictionary<string, string>();
         private readonly Dictionary<string, List<PlayMakerFSM>> indexedFsmCache = new Dictionary<string, List<PlayMakerFSM>>();
         private readonly Dictionary<string, List<PlayMakerFSM>> fsmListCache = new Dictionary<string, List<PlayMakerFSM>>();
@@ -86,8 +85,7 @@ namespace MWC_Localization_Core
 
         public void Initialize(TranslationContext ctx)
         {
-            this.translations = ctx.Translations;
-            this.magazineTranslations = ctx.MagazineTranslations;
+            this.translationContext = ctx;
             BuildTargets();
             ResetRuntimeState();
         }
@@ -136,16 +134,21 @@ namespace MWC_Localization_Core
 
         private void AddTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source)
         {
-            AddTargetRule(byKey, objectPath, fsmName, stateName, actionIndex, source, translations);
+            AddTargetRule(byKey, objectPath, fsmName, stateName, actionIndex, source, false);
         }
 
-        private void AddTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source, TranslationDictionary sourceTranslations)
+        private void AddMagazineTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source)
+        {
+            AddTargetRule(byKey, objectPath, fsmName, stateName, actionIndex, source, true);
+        }
+
+        private void AddTargetRule(Dictionary<string, FsmTarget> byKey, string objectPath, string fsmName, string stateName, int actionIndex, string source, bool useMagazineTranslations)
         {
             if (byKey == null || string.IsNullOrEmpty(objectPath) || string.IsNullOrEmpty(source))
                 return;
 
             string translation;
-            if (sourceTranslations == null || !sourceTranslations.TryGetExact(source, out translation))
+            if (!TryGetRuleTranslation(source, useMagazineTranslations, out translation))
                 return;
 
             string key = BuildKey(objectPath, fsmName, stateName, actionIndex);
@@ -157,6 +160,18 @@ namespace MWC_Localization_Core
             }
 
             target.Rules.Add(new FsmRule(source, translation));
+        }
+
+        private bool TryGetRuleTranslation(string source, bool useMagazineTranslations, out string translation)
+        {
+            translation = null;
+            if (translationContext == null)
+                return false;
+
+            if (useMagazineTranslations)
+                return translationContext.TryGetMagazine(source, out translation);
+
+            return translationContext.TryGetGlobal(source, out translation);
         }
 
         private static string BuildKey(string objectPath, string fsmName, string stateName, int actionIndex)

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -17,6 +17,7 @@ namespace MWC_Localization_Core
         public bool IsMonitoringComplete { get { return translatedPaths.Count >= targetPaths.Count; } }
 
         private TranslationDictionary translations;
+        private TranslationDictionary magazineTranslations;
         private readonly HashSet<string> targetPaths = new HashSet<string>();
         private readonly HashSet<string> translatedPaths = new HashSet<string>();
         private readonly Dictionary<string, PlayMakerHashTableProxy[]> proxyCache = new Dictionary<string, PlayMakerHashTableProxy[]>();
@@ -27,6 +28,7 @@ namespace MWC_Localization_Core
         public void Initialize(TranslationContext ctx)
         {
             translations = ctx.Translations;
+            magazineTranslations = ctx.MagazineTranslations;
             InitializeTargetPaths();
         }
 
@@ -219,6 +221,9 @@ namespace MWC_Localization_Core
         private string FindTranslation(string original)
         {
             string translated;
+            if (magazineTranslations != null && magazineTranslations.TryGetExact(original, out translated))
+                return translated;
+
             return translations != null && translations.TryGetExact(original, out translated)
                 ? translated
                 : null;

--- a/HashTableProxyHandler.cs
+++ b/HashTableProxyHandler.cs
@@ -16,8 +16,7 @@ namespace MWC_Localization_Core
         public bool IsComplete { get { return IsMonitoringComplete; } }
         public bool IsMonitoringComplete { get { return translatedPaths.Count >= targetPaths.Count; } }
 
-        private TranslationDictionary translations;
-        private TranslationDictionary magazineTranslations;
+        private TranslationContext translationContext;
         private readonly HashSet<string> targetPaths = new HashSet<string>();
         private readonly HashSet<string> translatedPaths = new HashSet<string>();
         private readonly Dictionary<string, PlayMakerHashTableProxy[]> proxyCache = new Dictionary<string, PlayMakerHashTableProxy[]>();
@@ -27,8 +26,7 @@ namespace MWC_Localization_Core
 
         public void Initialize(TranslationContext ctx)
         {
-            translations = ctx.Translations;
-            magazineTranslations = ctx.MagazineTranslations;
+            translationContext = ctx;
             InitializeTargetPaths();
         }
 
@@ -220,11 +218,11 @@ namespace MWC_Localization_Core
 
         private string FindTranslation(string original)
         {
-            string translated;
-            if (magazineTranslations != null && magazineTranslations.TryGetExact(original, out translated))
-                return translated;
+            if (translationContext == null)
+                return null;
 
-            return translations != null && translations.TryGetExact(original, out translated)
+            string translated;
+            return translationContext.TryGetMagazine(original, out translated)
                 ? translated
                 : null;
         }

--- a/MWC_Localization_Core.cs
+++ b/MWC_Localization_Core.cs
@@ -24,6 +24,7 @@ namespace MWC_Localization_Core
 
         // Shared state
         private TranslationDictionary translations = new TranslationDictionary();
+        private TranslationDictionary magazineTranslations = new TranslationDictionary();
         private Dictionary<string, Font> customFonts = new Dictionary<string, Font>();
         private LocalizationConfig config;
         private TextMeshTranslator translator;
@@ -71,6 +72,7 @@ namespace MWC_Localization_Core
             ModConsole.Print($"[{Name}] Main Menu loaded - initializing localization core...");
 
             translations = new TranslationDictionary();
+            magazineTranslations = new TranslationDictionary();
             customFonts = new Dictionary<string, Font>();
 
             config = new LocalizationConfig();
@@ -90,6 +92,7 @@ namespace MWC_Localization_Core
 
             ctx = new TranslationContext(
                 translations,
+                magazineTranslations,
                 customFonts,
                 config,
                 translator,
@@ -252,9 +255,9 @@ namespace MWC_Localization_Core
             if (!loaded.TryGetValue("PHONE", out phoneLabel) || string.IsNullOrEmpty(phoneLabel))
                 phoneLabel = "PHONE";
 
-            translations.AddAll(loaded);
-            translations.Add("h.", string.Empty);
-            translations.Add(",- puh.", " MK, " + phoneLabel + " -");
+            magazineTranslations.AddAll(loaded);
+            magazineTranslations.Add("h.", string.Empty);
+            magazineTranslations.Add(",- puh.", " MK, " + phoneLabel + " -");
             hasLoadedTranslations = true;
 
             if (File.Exists(path))
@@ -326,6 +329,7 @@ namespace MWC_Localization_Core
 
             // Drop translation data
             translations.Clear();
+            magazineTranslations.Clear();
             translations.ResetPatterns();
             for (int i = 0; i < surfaces.Count; i++)
                 surfaces[i].ClearTranslations();

--- a/TranslationSurface.cs
+++ b/TranslationSurface.cs
@@ -33,15 +33,18 @@ namespace MWC_Localization_Core
         public LocalizationConfig Config { get; private set; }
         public TextMeshTranslator Translator { get; private set; }
         public string AssetsFolder { get; private set; }
+        public TranslationDictionary MagazineTranslations { get; private set; }
 
         public TranslationContext(
             TranslationDictionary translations,
+            TranslationDictionary magazineTranslations,
             Dictionary<string, Font> customFonts,
             LocalizationConfig config,
             TextMeshTranslator translator,
             string assetsFolder)
         {
             Translations = translations;
+            MagazineTranslations = magazineTranslations;
             CustomFonts = customFonts;
             Config = config;
             Translator = translator;

--- a/TranslationSurface.cs
+++ b/TranslationSurface.cs
@@ -50,6 +50,19 @@ namespace MWC_Localization_Core
             Translator = translator;
             AssetsFolder = assetsFolder;
         }
+
+        public bool TryGetGlobal(string source, out string translation)
+        {
+            translation = null;
+            return Translations != null && Translations.TryGetExact(source, out translation);
+        }
+
+        public bool TryGetMagazine(string source, out string translation)
+        {
+            translation = null;
+            return MagazineTranslations != null && MagazineTranslations.TryGetExact(source, out translation);
+        }
+
     }
 
     /// <summary>


### PR DESCRIPTION
Correction: https://github.com/potatosalad775/MWC_Localization_Core/issues/95

## Fix magazine translation paths

This PR fixes the new magazine file paths and adds a patch to load magazine translations separately from the rest of the game translations.

This is needed for my language to avoid mixing item translations that require different wording depending on the context.

For example, `fender` needs to be abbreviated as `p/lama` in the magazine, while in the rest of the game it should remain `para-lamas`.

Separating the magazine translations also keeps the global dictionary smaller, since it no longer needs to include magazine-specific entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Yellow Pages Magazine layouts and formatting options, adding more page/row/list combinations for ads.
  * Magazine-specific localization: translations for magazine content are now stored and applied separately, improving accuracy for magazine text.
  * Reloadable magazine translation data so updates to magazine text take effect without impacting other translations.
  * Improved translation lookup for list/array content to better handle magazine-specific entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potatosalad775/MWC_Localization_Core/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->